### PR TITLE
testdump.c: remove code forgotten in commit 3051a87

### DIFF
--- a/src/testdump.c
+++ b/src/testdump.c
@@ -295,7 +295,6 @@ produce_full_dump (RECODE_SUBTASK subtask)
     {
       bool french = should_prefer_french();
       const char *charname;	/* charname for code */
-      const char *string;	/* environment value */
       char buffer[50];
 
       put_string (_("UCS2   Mne   Description\n\n"), subtask);

--- a/src/testdump.c
+++ b/src/testdump.c
@@ -298,19 +298,6 @@ produce_full_dump (RECODE_SUBTASK subtask)
       const char *string;	/* environment value */
       char buffer[50];
 
-      /* Decide if we prefer French or English output.  */
-
-      french = false;
-      string = getenv ("LANGUAGE");
-      if (string && string[0] == 'f' && string[1] == 'r')
-	french = true;
-      else
-	{
-	  string = getenv ("LANG");
-	  if (string && string[0] == 'f' && string[1] == 'r')
-	    french = true;
-	}
-
       put_string (_("UCS2   Mne   Description\n\n"), subtask);
 
       while (1)


### PR DESCRIPTION
Commit 3051a87 (from 2008) introduced function `should_prefer_french` as a better way to decide whether character names should be printed in English or in French. However a piece of code was forgotten in `produce_full_dump` during the refactoring, so that the result of `should_prefer_french` was erased and the obsolete decision procedure was still in use.

This commit fixes that.