### PR TITLE
test: Fix signedness mismatch

### DIFF
--- a/tests/Recode.pyx
+++ b/tests/Recode.pyx
@@ -604,7 +604,7 @@ cdef class Request:
     def pair_sequence(self):
         list = []
         cdef recode_step step
-        cdef unsigned counter
+        cdef short counter
         for counter from 0 <= counter < self.request.sequence_length:
             step = self.request.sequence_array[counter]
             list.append((step.before.name, step.after.name))


### PR DESCRIPTION
GCC 9.2.1 warns:

Recode.c: In function ‘__pyx_pf_6Recode_7Request_8pair_sequence’:
Recode.c:3096:45: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘short int’ [-Wsign-compare]
 3096 |   for (__pyx_v_counter = 0; __pyx_v_counter < __pyx_t_2; __pyx_v_counter++) {
      |                                             ^

A comparison between differently signed variable is dangerous because the
signed value is converted to an unsigned value of the same width and that
mangles the value and leads to comparing unintended values.

This patch fixes it.