### PR TITLE
Expand tabs

### DIFF
--- a/src/ansellat1.l
+++ b/src/ansellat1.l
@@ -82,14 +82,14 @@
  * ========
  * Fix ansel characters 
  * 
- * 	Capital C with cedilla
- * 	Lower case C with cedilla
- * 	Capital ETH 
- * 	Lower case eth
- * 	Capital O with slash
- * 	Capital Y with acute accent
- * 	Lower case Icelandic thorn     
- * 	capital OE ligature
+ *      Capital C with cedilla
+ *      Lower case C with cedilla
+ *      Capital ETH 
+ *      Lower case eth
+ *      Capital O with slash
+ *      Capital Y with acute accent
+ *      Lower case Icelandic thorn     
+ *      capital OE ligature
  * 
  * Thanks to Larry E. Dixson <ldix@loc.gov>
  * 

--- a/src/ascilat1.l
+++ b/src/ascilat1.l
@@ -22,62 +22,62 @@
 
 %%
 
-\<\b\"|\"\b\<			{ put_byte (171, subtask); }
-\>\b\"|\"\b\>			{ put_byte (187, subtask); }
-A\b`|`\bA			{ put_byte (192, subtask); }
-A\b'|'\bA			{ put_byte (193, subtask); }
-A\b^|^\bA			{ put_byte (194, subtask); }
-A\b~|~\bA			{ put_byte (195, subtask); }
-A\b\"|\"\bA			{ put_byte (196, subtask); }
-C\b,|,\bC			{ put_byte (199, subtask); }
-E\b`|`\bE			{ put_byte (200, subtask); }
-E\b'|'\bE			{ put_byte (201, subtask); }
-E\b^|^\bE			{ put_byte (202, subtask); }
-E\b\"|\"\bE			{ put_byte (203, subtask); }
-I\b`|`\bI			{ put_byte (204, subtask); }
-I\b'|'\bI			{ put_byte (205, subtask); }
-I\b^|^\bI			{ put_byte (206, subtask); }
-I\b\"|\"\bI			{ put_byte (207, subtask); }
-N\b~|~\bN			{ put_byte (209, subtask); }
-O\b`|`\bO			{ put_byte (210, subtask); }
-O\b'|'\bO			{ put_byte (211, subtask); }
-O\b^|^\bO			{ put_byte (212, subtask); }
-O\b~|~\bO			{ put_byte (213, subtask); }
-O\b\"|\"\bO			{ put_byte (214, subtask); }
-O\b\/|\/\bO			{ put_byte (216, subtask); }
-U\b`|`\bU			{ put_byte (217, subtask); }
-U\b'|'\bU			{ put_byte (218, subtask); }
-U\b^|^\bU			{ put_byte (219, subtask); }
-U\b\"|\"\bU			{ put_byte (220, subtask); }
-Y\b'|'\bY			{ put_byte (221, subtask); }
-s\b\"|\"\bs			{ put_byte (223, subtask); }
-a\b`|`\ba			{ put_byte (224, subtask); }
-a\b'|'\ba			{ put_byte (225, subtask); }
-a\b^|^\ba			{ put_byte (226, subtask); }
-a\b~|~\ba			{ put_byte (227, subtask); }
-a\b\"|\"\ba			{ put_byte (228, subtask); }
-c\b,|,\bc			{ put_byte (231, subtask); }
-e\b`|`\be			{ put_byte (232, subtask); }
-e\b'|'\be			{ put_byte (233, subtask); }
-e\b^|^\be			{ put_byte (234, subtask); }
-e\b\"|\"\be			{ put_byte (235, subtask); }
-i\b`|`\bi			{ put_byte (236, subtask); }
-i\b'|'\bi			{ put_byte (237, subtask); }
-i\b^|^\bi			{ put_byte (238, subtask); }
-i\b\"|\"\bi			{ put_byte (239, subtask); }
-n\b~|~\bn			{ put_byte (241, subtask); }
-o\b`|`\bo			{ put_byte (242, subtask); }
-o\b'|'\bo			{ put_byte (243, subtask); }
-o\b^|^\bo			{ put_byte (244, subtask); }
-o\b~|~\bo			{ put_byte (245, subtask); }
-o\b\"|\"\bo			{ put_byte (246, subtask); }
-o\b\/|\/\bo			{ put_byte (248, subtask); }
-u\b`|`\bu			{ put_byte (249, subtask); }
-u\b'|'\bu			{ put_byte (250, subtask); }
-u\b^|^\bu			{ put_byte (251, subtask); }
-u\b\"|\"\bu			{ put_byte (252, subtask); }
-y\b'|'\by			{ put_byte (253, subtask); }
-y\b\"|\"\by			{ put_byte (255, subtask); }
+\<\b\"|\"\b\<                   { put_byte (171, subtask); }
+\>\b\"|\"\b\>                   { put_byte (187, subtask); }
+A\b`|`\bA                       { put_byte (192, subtask); }
+A\b'|'\bA                       { put_byte (193, subtask); }
+A\b^|^\bA                       { put_byte (194, subtask); }
+A\b~|~\bA                       { put_byte (195, subtask); }
+A\b\"|\"\bA                     { put_byte (196, subtask); }
+C\b,|,\bC                       { put_byte (199, subtask); }
+E\b`|`\bE                       { put_byte (200, subtask); }
+E\b'|'\bE                       { put_byte (201, subtask); }
+E\b^|^\bE                       { put_byte (202, subtask); }
+E\b\"|\"\bE                     { put_byte (203, subtask); }
+I\b`|`\bI                       { put_byte (204, subtask); }
+I\b'|'\bI                       { put_byte (205, subtask); }
+I\b^|^\bI                       { put_byte (206, subtask); }
+I\b\"|\"\bI                     { put_byte (207, subtask); }
+N\b~|~\bN                       { put_byte (209, subtask); }
+O\b`|`\bO                       { put_byte (210, subtask); }
+O\b'|'\bO                       { put_byte (211, subtask); }
+O\b^|^\bO                       { put_byte (212, subtask); }
+O\b~|~\bO                       { put_byte (213, subtask); }
+O\b\"|\"\bO                     { put_byte (214, subtask); }
+O\b\/|\/\bO                     { put_byte (216, subtask); }
+U\b`|`\bU                       { put_byte (217, subtask); }
+U\b'|'\bU                       { put_byte (218, subtask); }
+U\b^|^\bU                       { put_byte (219, subtask); }
+U\b\"|\"\bU                     { put_byte (220, subtask); }
+Y\b'|'\bY                       { put_byte (221, subtask); }
+s\b\"|\"\bs                     { put_byte (223, subtask); }
+a\b`|`\ba                       { put_byte (224, subtask); }
+a\b'|'\ba                       { put_byte (225, subtask); }
+a\b^|^\ba                       { put_byte (226, subtask); }
+a\b~|~\ba                       { put_byte (227, subtask); }
+a\b\"|\"\ba                     { put_byte (228, subtask); }
+c\b,|,\bc                       { put_byte (231, subtask); }
+e\b`|`\be                       { put_byte (232, subtask); }
+e\b'|'\be                       { put_byte (233, subtask); }
+e\b^|^\be                       { put_byte (234, subtask); }
+e\b\"|\"\be                     { put_byte (235, subtask); }
+i\b`|`\bi                       { put_byte (236, subtask); }
+i\b'|'\bi                       { put_byte (237, subtask); }
+i\b^|^\bi                       { put_byte (238, subtask); }
+i\b\"|\"\bi                     { put_byte (239, subtask); }
+n\b~|~\bn                       { put_byte (241, subtask); }
+o\b`|`\bo                       { put_byte (242, subtask); }
+o\b'|'\bo                       { put_byte (243, subtask); }
+o\b^|^\bo                       { put_byte (244, subtask); }
+o\b~|~\bo                       { put_byte (245, subtask); }
+o\b\"|\"\bo                     { put_byte (246, subtask); }
+o\b\/|\/\bo                     { put_byte (248, subtask); }
+u\b`|`\bu                       { put_byte (249, subtask); }
+u\b'|'\bu                       { put_byte (250, subtask); }
+u\b^|^\bu                       { put_byte (251, subtask); }
+u\b\"|\"\bu                     { put_byte (252, subtask); }
+y\b'|'\by                       { put_byte (253, subtask); }
+y\b\"|\"\by                     { put_byte (255, subtask); }
 
 %%
 
@@ -85,8 +85,8 @@ bool
 module_ascii_latin1 (RECODE_OUTER outer)
 {
   if (!declare_single (outer, "ASCII-BS", "Latin-1",
-		       outer->quality_variable_to_byte,
-		       NULL, transform_ascii_latin1))
+                       outer->quality_variable_to_byte,
+                       NULL, transform_ascii_latin1))
     return false;
 
   return true;

--- a/src/bangbang.c
+++ b/src/bangbang.c
@@ -23,271 +23,271 @@
 
 static const char *const translation_table[256] =
   {
-    "!!@",			/*   0 */
-    "!!a",			/*   1 */
-    "!!b",			/*   2 */
-    "!!c",			/*   3 */
-    "!!d",			/*   4 */
-    "!!e",			/*   5 */
-    "!!f",			/*   6 */
-    "!!g",			/*   7 */
-    "!!h",			/*   8 */
-    "!!i",			/*   9 */
-    "\n",			/*  10, would have been "!!j" */
-    "!!k",			/*  11 */
-    "!!l",			/*  12 */
-    "!!m",			/*  13 */
-    "!!n",			/*  14 */
-    "!!o",			/*  15 */
-    "!!p",			/*  16 */
-    "!!q",			/*  17 */
-    "!!r",			/*  18 */
-    "!!s",			/*  19 */
-    "!!t",			/*  20 */
-    "!!u",			/*  21 */
-    "!!v",			/*  22 */
-    "!!w",			/*  23 */
-    "!!x",			/*  24 */
-    "!!y",			/*  25 */
-    "!!z",			/*  26 */
-    "!![",			/*  27 */
-    "!!\\",			/*  28 */
-    "!!]",			/*  29 */
-    "!!^",			/*  30 */
-    "!!_",			/*  31 */
-    " ",			/*  32 */
-    "!\"",			/*  33 */
-    "\"",			/*  34 */
-    "#",			/*  35 */
-    "$",			/*  36 */
-    "%",			/*  37 */
-    "&",			/*  38 */
-    "'",			/*  39 */
-    "(",			/*  40 */
-    ")",			/*  41 */
-    "*",			/*  42 */
-    "+",			/*  43 */
-    ",",			/*  44 */
-    "-",			/*  45 */
-    ".",			/*  46 */
-    "/",			/*  47 */
-    "0",			/*  48 */
-    "1",			/*  49 */
-    "2",			/*  50 */
-    "3",			/*  51 */
-    "4",			/*  52 */
-    "5",			/*  53 */
-    "6",			/*  54 */
-    "7",			/*  55 */
-    "8",			/*  56 */
-    "9",			/*  57 */
-    ":",			/*  58 */
-    ";",			/*  59 */
-    "<",			/*  60 */
-    "=",			/*  61 */
-    ">",			/*  62 */
-    "?",			/*  63 */
-    "@",			/*  64 */
-    "!a",			/*  65 */
-    "!b",			/*  66 */
-    "!c",			/*  67 */
-    "!d",			/*  68 */
-    "!e",			/*  69 */
-    "!f",			/*  70 */
-    "!g",			/*  71 */
-    "!h",			/*  72 */
-    "!i",			/*  73 */
-    "!j",			/*  74 */
-    "!k",			/*  75 */
-    "!l",			/*  76 */
-    "!m",			/*  77 */
-    "!n",			/*  78 */
-    "!o",			/*  79 */
-    "!p",			/*  80 */
-    "!q",			/*  81 */
-    "!r",			/*  82 */
-    "!s",			/*  83 */
-    "!t",			/*  84 */
-    "!u",			/*  85 */
-    "!v",			/*  86 */
-    "!w",			/*  87 */
-    "!x",			/*  88 */
-    "!y",			/*  89 */
-    "!z",			/*  90 */
-    "[",			/*  91 */
-    "\\",			/*  92 */
-    "]",			/*  93 */
-    "^",			/*  94 */
-    "_",			/*  95 */
-    "!@",			/*  96 */
-    "a",			/*  97 */
-    "b",			/*  98 */
-    "c",			/*  99 */
-    "d",			/* 100 */
-    "e",			/* 101 */
-    "f",			/* 102 */
-    "g",			/* 103 */
-    "h",			/* 104 */
-    "i",			/* 105 */
-    "j",			/* 106 */
-    "k",			/* 107 */
-    "l",			/* 108 */
-    "m",			/* 109 */
-    "n",			/* 110 */
-    "o",			/* 111 */
-    "p",			/* 112 */
-    "q",			/* 113 */
-    "r",			/* 114 */
-    "s",			/* 115 */
-    "t",			/* 116 */
-    "u",			/* 117 */
-    "v",			/* 118 */
-    "w",			/* 119 */
-    "x",			/* 120 */
-    "y",			/* 121 */
-    "z",			/* 122 */
-    "![",			/* 123 */
-    "!\\",			/* 124 */
-    "!]",			/* 125 */
-    "!^",			/* 126 */
-    "!_",			/* 127 */
+    "!!@",                      /*   0 */
+    "!!a",                      /*   1 */
+    "!!b",                      /*   2 */
+    "!!c",                      /*   3 */
+    "!!d",                      /*   4 */
+    "!!e",                      /*   5 */
+    "!!f",                      /*   6 */
+    "!!g",                      /*   7 */
+    "!!h",                      /*   8 */
+    "!!i",                      /*   9 */
+    "\n",                       /*  10, would have been "!!j" */
+    "!!k",                      /*  11 */
+    "!!l",                      /*  12 */
+    "!!m",                      /*  13 */
+    "!!n",                      /*  14 */
+    "!!o",                      /*  15 */
+    "!!p",                      /*  16 */
+    "!!q",                      /*  17 */
+    "!!r",                      /*  18 */
+    "!!s",                      /*  19 */
+    "!!t",                      /*  20 */
+    "!!u",                      /*  21 */
+    "!!v",                      /*  22 */
+    "!!w",                      /*  23 */
+    "!!x",                      /*  24 */
+    "!!y",                      /*  25 */
+    "!!z",                      /*  26 */
+    "!![",                      /*  27 */
+    "!!\\",                     /*  28 */
+    "!!]",                      /*  29 */
+    "!!^",                      /*  30 */
+    "!!_",                      /*  31 */
+    " ",                        /*  32 */
+    "!\"",                      /*  33 */
+    "\"",                       /*  34 */
+    "#",                        /*  35 */
+    "$",                        /*  36 */
+    "%",                        /*  37 */
+    "&",                        /*  38 */
+    "'",                        /*  39 */
+    "(",                        /*  40 */
+    ")",                        /*  41 */
+    "*",                        /*  42 */
+    "+",                        /*  43 */
+    ",",                        /*  44 */
+    "-",                        /*  45 */
+    ".",                        /*  46 */
+    "/",                        /*  47 */
+    "0",                        /*  48 */
+    "1",                        /*  49 */
+    "2",                        /*  50 */
+    "3",                        /*  51 */
+    "4",                        /*  52 */
+    "5",                        /*  53 */
+    "6",                        /*  54 */
+    "7",                        /*  55 */
+    "8",                        /*  56 */
+    "9",                        /*  57 */
+    ":",                        /*  58 */
+    ";",                        /*  59 */
+    "<",                        /*  60 */
+    "=",                        /*  61 */
+    ">",                        /*  62 */
+    "?",                        /*  63 */
+    "@",                        /*  64 */
+    "!a",                       /*  65 */
+    "!b",                       /*  66 */
+    "!c",                       /*  67 */
+    "!d",                       /*  68 */
+    "!e",                       /*  69 */
+    "!f",                       /*  70 */
+    "!g",                       /*  71 */
+    "!h",                       /*  72 */
+    "!i",                       /*  73 */
+    "!j",                       /*  74 */
+    "!k",                       /*  75 */
+    "!l",                       /*  76 */
+    "!m",                       /*  77 */
+    "!n",                       /*  78 */
+    "!o",                       /*  79 */
+    "!p",                       /*  80 */
+    "!q",                       /*  81 */
+    "!r",                       /*  82 */
+    "!s",                       /*  83 */
+    "!t",                       /*  84 */
+    "!u",                       /*  85 */
+    "!v",                       /*  86 */
+    "!w",                       /*  87 */
+    "!x",                       /*  88 */
+    "!y",                       /*  89 */
+    "!z",                       /*  90 */
+    "[",                        /*  91 */
+    "\\",                       /*  92 */
+    "]",                        /*  93 */
+    "^",                        /*  94 */
+    "_",                        /*  95 */
+    "!@",                       /*  96 */
+    "a",                        /*  97 */
+    "b",                        /*  98 */
+    "c",                        /*  99 */
+    "d",                        /* 100 */
+    "e",                        /* 101 */
+    "f",                        /* 102 */
+    "g",                        /* 103 */
+    "h",                        /* 104 */
+    "i",                        /* 105 */
+    "j",                        /* 106 */
+    "k",                        /* 107 */
+    "l",                        /* 108 */
+    "m",                        /* 109 */
+    "n",                        /* 110 */
+    "o",                        /* 111 */
+    "p",                        /* 112 */
+    "q",                        /* 113 */
+    "r",                        /* 114 */
+    "s",                        /* 115 */
+    "t",                        /* 116 */
+    "u",                        /* 117 */
+    "v",                        /* 118 */
+    "w",                        /* 119 */
+    "x",                        /* 120 */
+    "y",                        /* 121 */
+    "z",                        /* 122 */
+    "![",                       /* 123 */
+    "!\\",                      /* 124 */
+    "!]",                       /* 125 */
+    "!^",                       /* 126 */
+    "!_",                       /* 127 */
 
-    NULL,			/* 128 */
-    NULL,			/* 129 */
-    NULL,			/* 130 */
-    NULL,			/* 131 */
-    NULL,			/* 132 */
-    NULL,			/* 133 */
-    NULL,			/* 134 */
-    NULL,			/* 135 */
-    NULL,			/* 136 */
-    NULL,			/* 137 */
-    NULL,			/* 138 */
-    NULL,			/* 139 */
-    NULL,			/* 140 */
-    NULL,			/* 141 */
-    NULL,			/* 142 */
-    NULL,			/* 143 */
-    NULL,			/* 144 */
-    NULL,			/* 145 */
-    NULL,			/* 146 */
-    NULL,			/* 147 */
-    NULL,			/* 148 */
-    NULL,			/* 149 */
-    NULL,			/* 150 */
-    NULL,			/* 151 */
-    NULL,			/* 152 */
-    NULL,			/* 153 */
-    NULL,			/* 154 */
-    NULL,			/* 155 */
-    NULL,			/* 156 */
-    NULL,			/* 157 */
-    NULL,			/* 158 */
-    NULL,			/* 159 */
+    NULL,                       /* 128 */
+    NULL,                       /* 129 */
+    NULL,                       /* 130 */
+    NULL,                       /* 131 */
+    NULL,                       /* 132 */
+    NULL,                       /* 133 */
+    NULL,                       /* 134 */
+    NULL,                       /* 135 */
+    NULL,                       /* 136 */
+    NULL,                       /* 137 */
+    NULL,                       /* 138 */
+    NULL,                       /* 139 */
+    NULL,                       /* 140 */
+    NULL,                       /* 141 */
+    NULL,                       /* 142 */
+    NULL,                       /* 143 */
+    NULL,                       /* 144 */
+    NULL,                       /* 145 */
+    NULL,                       /* 146 */
+    NULL,                       /* 147 */
+    NULL,                       /* 148 */
+    NULL,                       /* 149 */
+    NULL,                       /* 150 */
+    NULL,                       /* 151 */
+    NULL,                       /* 152 */
+    NULL,                       /* 153 */
+    NULL,                       /* 154 */
+    NULL,                       /* 155 */
+    NULL,                       /* 156 */
+    NULL,                       /* 157 */
+    NULL,                       /* 158 */
+    NULL,                       /* 159 */
 
-    " ",			/* 160 no-break space */
-    NULL,			/* 161 inverted exclamation mark */
-    NULL,			/* 162 cent sign */
-    NULL,			/* 163 pound sign */
-    NULL,			/* 164 currency sign */
-    NULL,			/* 165 yen sign */
-    NULL,			/* 166 broken bar */
-    NULL,			/* 167 paragraph sign, section sign */
-    NULL,			/* 168 diaeresis */
-    NULL,			/* 169 copyright sign */
-    NULL,			/* 170 feminine ordinal indicator */
-    "!>",			/* 171 left angle quotation mark */
-    NULL,			/* 172 not sign */
-    NULL,			/* 173 soft hyphen */
-    NULL,			/* 174 registered trade mark sign */
-    NULL,			/* 175 macron */
-    NULL,			/* 176 degree sign */
-    NULL,			/* 177 plus-minus sign */
-    NULL,			/* 178 superscript two */
-    NULL,			/* 179 superscript three */
-    NULL,			/* 180 acute accent */
-    NULL,			/* 181 small greek mu, micro sign */
-    NULL,			/* 182 pilcrow sign */
-    NULL,			/* 183 middle dot */
-    NULL,			/* 184 cedilla */
-    NULL,			/* 185 superscript one */
-    NULL,			/* 186 masculine ordinal indicator */
-    "!?",			/* 187 right angle quotation mark */
-    NULL,			/* 188 vulgar fraction one quarter */
-    NULL,			/* 189 vulgar fraction one half */
-    NULL,			/* 190 vulgar fraction three quarters */
-    NULL,			/* 191 inverted question mark */
-    NULL,			/* 192 capital A with grave accent */
-    NULL,			/* 193 capital A with acute accent */
-    NULL,			/* 194 capital A with circumflex accent */
-    NULL,			/* 195 capital A with tilde */
-    NULL,			/* 196 capital A diaeresis */
-    NULL,			/* 197 capital A with ring above */
-    NULL,			/* 198 capital diphthong A with E */
-    NULL,			/* 199 capital C with cedilla */
-    NULL,			/* 200 capital E with grave accent */
-    NULL,			/* 201 capital E with acute accent */
-    NULL,			/* 202 capital E with circumflex accent */
-    NULL,			/* 203 capital E with diaeresis */
-    NULL,			/* 204 capital I with grave accent */
-    NULL,			/* 205 capital I with acute accent */
-    NULL,			/* 206 capital I with circumflex accent */
-    NULL,			/* 207 capital I with diaeresis */
-    NULL,			/* 208 capital icelandic ETH */
-    NULL,			/* 209 capital N with tilde */
-    NULL,			/* 210 capital O with grave accent */
-    NULL,			/* 211 capital O with acute accent */
-    NULL,			/* 212 capital O with circumflex accent */
-    NULL,			/* 213 capital O with tilde */
-    NULL,			/* 214 capital O with diaeresis */
-    NULL,			/* 215 multiplication sign */
-    NULL,			/* 216 capital O with oblique stroke */
-    NULL,			/* 217 capital U with grave accent */
-    NULL,			/* 218 capital U with acute accent */
-    NULL,			/* 219 capital U with circumflex accent */
-    NULL,			/* 220 capital U with diaeresis */
-    NULL,			/* 221 capital Y with acute accent */
-    NULL,			/* 222 capital icelandic THORN */
-    NULL,			/* 223 small german sharp s */
-    "!0",			/* 224 small a with grave accent */
-    NULL,			/* 225 small a with acute accent */
-    "!1",			/* 226 small a with circumflex accent */
-    NULL,			/* 227 small a with tilde */
-    NULL,			/* 228 small a with diaeresis */
-    NULL,			/* 229 small a with ring above */
-    "!;",			/* 230 small diphthong a with e */
-    "!=",			/* 231 small c with cedilla */
-    "!3",			/* 232 small e with grave accent */
-    "!2",			/* 233 small e with acute accent */
-    "!5",			/* 234 small e with circumflex accent */
-    "!4",			/* 235 small e with diaeresis */
-    NULL,			/* 236 small i with grave accent */
-    NULL,			/* 237 small i with acute accent */
-    "!7",			/* 238 small i with circumflex accent */
-    "!6",			/* 239 small i with diaeresis */
-    NULL,			/* 240 small icelandic eth */
-    NULL,			/* 241 small n with tilde */
-    NULL,			/* 242 small o with grave accent */
-    NULL,			/* 243 small o with acute accent */
-    "!8",			/* 244 small o with circumflex accent */
-    NULL,			/* 245 small o with tilde */
-    NULL,			/* 246 small o with diaeresis */
-    "!<",			/* 247 division sign (or French oe?) */
-    NULL,			/* 248 small o with oblique stroke */
-    "!9",			/* 249 small u with grave accent */
-    NULL,			/* 250 small u with acute accent */
-    "!:",			/* 251 small u with circumflex accent */
-    NULL,			/* 252 small u with diaeresis */
-    NULL,			/* 253 small y with acute accent */
-    NULL,			/* 254 small icelandic thorn */
-    NULL,			/* 255 small y with diaeresis */
+    " ",                        /* 160 no-break space */
+    NULL,                       /* 161 inverted exclamation mark */
+    NULL,                       /* 162 cent sign */
+    NULL,                       /* 163 pound sign */
+    NULL,                       /* 164 currency sign */
+    NULL,                       /* 165 yen sign */
+    NULL,                       /* 166 broken bar */
+    NULL,                       /* 167 paragraph sign, section sign */
+    NULL,                       /* 168 diaeresis */
+    NULL,                       /* 169 copyright sign */
+    NULL,                       /* 170 feminine ordinal indicator */
+    "!>",                       /* 171 left angle quotation mark */
+    NULL,                       /* 172 not sign */
+    NULL,                       /* 173 soft hyphen */
+    NULL,                       /* 174 registered trade mark sign */
+    NULL,                       /* 175 macron */
+    NULL,                       /* 176 degree sign */
+    NULL,                       /* 177 plus-minus sign */
+    NULL,                       /* 178 superscript two */
+    NULL,                       /* 179 superscript three */
+    NULL,                       /* 180 acute accent */
+    NULL,                       /* 181 small greek mu, micro sign */
+    NULL,                       /* 182 pilcrow sign */
+    NULL,                       /* 183 middle dot */
+    NULL,                       /* 184 cedilla */
+    NULL,                       /* 185 superscript one */
+    NULL,                       /* 186 masculine ordinal indicator */
+    "!?",                       /* 187 right angle quotation mark */
+    NULL,                       /* 188 vulgar fraction one quarter */
+    NULL,                       /* 189 vulgar fraction one half */
+    NULL,                       /* 190 vulgar fraction three quarters */
+    NULL,                       /* 191 inverted question mark */
+    NULL,                       /* 192 capital A with grave accent */
+    NULL,                       /* 193 capital A with acute accent */
+    NULL,                       /* 194 capital A with circumflex accent */
+    NULL,                       /* 195 capital A with tilde */
+    NULL,                       /* 196 capital A diaeresis */
+    NULL,                       /* 197 capital A with ring above */
+    NULL,                       /* 198 capital diphthong A with E */
+    NULL,                       /* 199 capital C with cedilla */
+    NULL,                       /* 200 capital E with grave accent */
+    NULL,                       /* 201 capital E with acute accent */
+    NULL,                       /* 202 capital E with circumflex accent */
+    NULL,                       /* 203 capital E with diaeresis */
+    NULL,                       /* 204 capital I with grave accent */
+    NULL,                       /* 205 capital I with acute accent */
+    NULL,                       /* 206 capital I with circumflex accent */
+    NULL,                       /* 207 capital I with diaeresis */
+    NULL,                       /* 208 capital icelandic ETH */
+    NULL,                       /* 209 capital N with tilde */
+    NULL,                       /* 210 capital O with grave accent */
+    NULL,                       /* 211 capital O with acute accent */
+    NULL,                       /* 212 capital O with circumflex accent */
+    NULL,                       /* 213 capital O with tilde */
+    NULL,                       /* 214 capital O with diaeresis */
+    NULL,                       /* 215 multiplication sign */
+    NULL,                       /* 216 capital O with oblique stroke */
+    NULL,                       /* 217 capital U with grave accent */
+    NULL,                       /* 218 capital U with acute accent */
+    NULL,                       /* 219 capital U with circumflex accent */
+    NULL,                       /* 220 capital U with diaeresis */
+    NULL,                       /* 221 capital Y with acute accent */
+    NULL,                       /* 222 capital icelandic THORN */
+    NULL,                       /* 223 small german sharp s */
+    "!0",                       /* 224 small a with grave accent */
+    NULL,                       /* 225 small a with acute accent */
+    "!1",                       /* 226 small a with circumflex accent */
+    NULL,                       /* 227 small a with tilde */
+    NULL,                       /* 228 small a with diaeresis */
+    NULL,                       /* 229 small a with ring above */
+    "!;",                       /* 230 small diphthong a with e */
+    "!=",                       /* 231 small c with cedilla */
+    "!3",                       /* 232 small e with grave accent */
+    "!2",                       /* 233 small e with acute accent */
+    "!5",                       /* 234 small e with circumflex accent */
+    "!4",                       /* 235 small e with diaeresis */
+    NULL,                       /* 236 small i with grave accent */
+    NULL,                       /* 237 small i with acute accent */
+    "!7",                       /* 238 small i with circumflex accent */
+    "!6",                       /* 239 small i with diaeresis */
+    NULL,                       /* 240 small icelandic eth */
+    NULL,                       /* 241 small n with tilde */
+    NULL,                       /* 242 small o with grave accent */
+    NULL,                       /* 243 small o with acute accent */
+    "!8",                       /* 244 small o with circumflex accent */
+    NULL,                       /* 245 small o with tilde */
+    NULL,                       /* 246 small o with diaeresis */
+    "!<",                       /* 247 division sign (or French oe?) */
+    NULL,                       /* 248 small o with oblique stroke */
+    "!9",                       /* 249 small u with grave accent */
+    NULL,                       /* 250 small u with acute accent */
+    "!:",                       /* 251 small u with circumflex accent */
+    NULL,                       /* 252 small u with diaeresis */
+    NULL,                       /* 253 small y with acute accent */
+    NULL,                       /* 254 small icelandic thorn */
+    NULL,                       /* 255 small y with diaeresis */
   };
 
 static bool
 init_latin1_bangbang (RECODE_STEP step,
-		      RECODE_CONST_REQUEST request _GL_UNUSED,
-		      RECODE_CONST_OPTION_LIST before_options,
-		      RECODE_CONST_OPTION_LIST after_options)
+                      RECODE_CONST_REQUEST request _GL_UNUSED,
+                      RECODE_CONST_OPTION_LIST before_options,
+                      RECODE_CONST_OPTION_LIST after_options)
 {
   if (before_options || after_options)
     return false;
@@ -301,80 +301,80 @@ init_latin1_bangbang (RECODE_STEP step,
 static bool
 transform_bangbang_latin1 (RECODE_SUBTASK subtask)
 {
-  int input_char;		/* current character */
+  int input_char;               /* current character */
 
   while (input_char = get_byte (subtask), input_char != EOF)
     {
       if (input_char >= 'A' && input_char <= 'Z')
         input_char += 'a' - 'A';
       else if (input_char == '!')
-	{
-	  input_char = get_byte (subtask);
-	  if (input_char >= 'a' && input_char <= 'z')
-	    input_char += 'A' - 'a';
-	  else if (input_char < 'A' || input_char > 'Z')
-	    switch (input_char)
-	      {
-	      case '"': input_char = '!'; break;
-	      case '0': input_char = 224; break; /* a` */
-	      case '1': input_char = 226; break; /* a^ */
-	      case '2': input_char = 233; break; /* e' */
-	      case '3': input_char = 232; break; /* e` */
-	      case '4': input_char = 235; break; /* e" */
-	      case '5': input_char = 234; break; /* e^ */
-	      case '6': input_char = 236; break; /* e" */
-	      case '7': input_char = 238; break; /* i^ */
-	      case '8': input_char = 244; break; /* o^ */
-	      case '9': input_char = 249; break; /* u` */
-	      case ':': input_char = 251; break; /* u^ */
-	      case '=': input_char = 231; break; /* c, */
-	      case '>': input_char = 171; break; /* `` */
-	      case '?': input_char = 187; break; /* '' */
-	      case ';': input_char = 230; break; /* ae */
-	      case '<':	input_char = 247; break; /* oe ??? */
-	      case '@': input_char = '`'; break;
-	      case '[': input_char = '{'; break;
-	      case '\\': input_char = '|'; break;
-	      case ']': input_char = '}'; break;
-	      case '^': input_char = '~'; break;
-	      case '_': input_char = 127; break; /* del */
+        {
+          input_char = get_byte (subtask);
+          if (input_char >= 'a' && input_char <= 'z')
+            input_char += 'A' - 'a';
+          else if (input_char < 'A' || input_char > 'Z')
+            switch (input_char)
+              {
+              case '"': input_char = '!'; break;
+              case '0': input_char = 224; break; /* a` */
+              case '1': input_char = 226; break; /* a^ */
+              case '2': input_char = 233; break; /* e' */
+              case '3': input_char = 232; break; /* e` */
+              case '4': input_char = 235; break; /* e" */
+              case '5': input_char = 234; break; /* e^ */
+              case '6': input_char = 236; break; /* e" */
+              case '7': input_char = 238; break; /* i^ */
+              case '8': input_char = 244; break; /* o^ */
+              case '9': input_char = 249; break; /* u` */
+              case ':': input_char = 251; break; /* u^ */
+              case '=': input_char = 231; break; /* c, */
+              case '>': input_char = 171; break; /* `` */
+              case '?': input_char = 187; break; /* '' */
+              case ';': input_char = 230; break; /* ae */
+              case '<': input_char = 247; break; /* oe ??? */
+              case '@': input_char = '`'; break;
+              case '[': input_char = '{'; break;
+              case '\\': input_char = '|'; break;
+              case ']': input_char = '}'; break;
+              case '^': input_char = '~'; break;
+              case '_': input_char = 127; break; /* del */
 
-	      case '!':
-	        input_char = get_byte (subtask);
-		if (input_char == 'J' || input_char == 'j')
-		  RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
+              case '!':
+                input_char = get_byte (subtask);
+                if (input_char == 'J' || input_char == 'j')
+                  RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
 
-		/* FIXME: What is canonical?  Upper case or lower case?  */
-		if (input_char >= 'A' && input_char <= 'Z')
-		  input_char += 1 - 'A';
-	        else if (input_char >= 'a' && input_char <= 'z')
-		  input_char += 1 - 'a';
-	        else
-		  switch (input_char)
-		    {
-		    case '@': input_char = 0; break;
-		    case '[': input_char = 27; break;
-		    case '\\': input_char = 28; break;
-		    case ']': input_char = 29; break;
-		    case '^': input_char = 30; break;
-		    case '_': input_char = 31; break;
+                /* FIXME: What is canonical?  Upper case or lower case?  */
+                if (input_char >= 'A' && input_char <= 'Z')
+                  input_char += 1 - 'A';
+                else if (input_char >= 'a' && input_char <= 'z')
+                  input_char += 1 - 'a';
+                else
+                  switch (input_char)
+                    {
+                    case '@': input_char = 0; break;
+                    case '[': input_char = 27; break;
+                    case '\\': input_char = 28; break;
+                    case ']': input_char = 29; break;
+                    case '^': input_char = 30; break;
+                    case '_': input_char = 31; break;
 
-		    default:
-		      RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-		      put_byte ('!', subtask);
-		      put_byte ('!', subtask);
-		      if (input_char == EOF)
-		        SUBTASK_RETURN (subtask);
-		    }
-		break;
+                    default:
+                      RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+                      put_byte ('!', subtask);
+                      put_byte ('!', subtask);
+                      if (input_char == EOF)
+                        SUBTASK_RETURN (subtask);
+                    }
+                break;
 
-	      default:
-		RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-	        put_byte ('!', subtask);
-	        if (input_char == EOF)
-		  SUBTASK_RETURN (subtask);
-	      }
-	}
+              default:
+                RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+                put_byte ('!', subtask);
+                if (input_char == EOF)
+                  SUBTASK_RETURN (subtask);
+              }
+        }
       put_byte (input_char, subtask);
     }
   SUBTASK_RETURN (subtask);
@@ -385,11 +385,11 @@ module_bangbang (RECODE_OUTER outer)
 {
   return
     declare_single (outer, "Latin-1", "Bang-Bang",
-		    outer->quality_byte_to_variable,
-		    init_latin1_bangbang, transform_byte_to_variable)
+                    outer->quality_byte_to_variable,
+                    init_latin1_bangbang, transform_byte_to_variable)
     && declare_single (outer, "Bang-Bang", "Latin-1",
-		       outer->quality_variable_to_byte,
-		       NULL, transform_bangbang_latin1);
+                       outer->quality_variable_to_byte,
+                       NULL, transform_bangbang_latin1);
 }
 
 void

--- a/src/base64.c
+++ b/src/base64.c
@@ -25,32 +25,32 @@
 /* Table of characters coding the 64 values.  */
 char base64_value_to_char[64] =
 {
-  'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J',	/*  0- 9 */
-  'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T',	/* 10-19 */
-  'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd',	/* 20-29 */
-  'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n',	/* 30-39 */
-  'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x',	/* 40-49 */
-  'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7',	/* 50-59 */
-  '8', '9', '+', '/'					/* 60-63 */
+  'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J',     /*  0- 9 */
+  'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T',     /* 10-19 */
+  'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd',     /* 20-29 */
+  'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n',     /* 30-39 */
+  'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x',     /* 40-49 */
+  'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7',     /* 50-59 */
+  '8', '9', '+', '/'                                    /* 60-63 */
 };
 
 /* Table of base64 values for first 128 characters.  */
 #define z -1
 short base64_char_to_value[128] =
 {
-  z,   z,   z,   z,   z,   z,   z,   z,   z,   z,	/*   0-  9 */
-  z,   z,   z,   z,   z,   z,   z,   z,   z,   z,	/*  10- 19 */
-  z,   z,   z,   z,   z,   z,   z,   z,   z,   z,	/*  20- 29 */
-  z,   z,   z,   z,   z,   z,   z,   z,   z,   z,	/*  30- 39 */
-  z,   z,   z,   62,  z,   z,   z,   63,  52,  53,	/*  40- 49 */
-  54,  55,  56,  57,  58,  59,  60,  61,  z,   z,	/*  50- 59 */
-  z,   z,   z,   z,   z,   0,   1,   2,   3,   4,	/*  60- 69 */
-  5,   6,   7,   8,   9,   10,  11,  12,  13,  14,	/*  70- 79 */
-  15,  16,  17,  18,  19,  20,  21,  22,  23,  24,	/*  80- 89 */
-  25,  z,   z,   z,   z,   z,   z,   26,  27,  28,	/*  90- 99 */
-  29,  30,  31,  32,  33,  34,  35,  36,  37,  38,	/* 100-109 */
-  39,  40,  41,  42,  43,  44,  45,  46,  47,  48,	/* 110-119 */
-  49,  50,  51,  z,   z,   z,   z,   z			/* 120-127 */
+  z,   z,   z,   z,   z,   z,   z,   z,   z,   z,       /*   0-  9 */
+  z,   z,   z,   z,   z,   z,   z,   z,   z,   z,       /*  10- 19 */
+  z,   z,   z,   z,   z,   z,   z,   z,   z,   z,       /*  20- 29 */
+  z,   z,   z,   z,   z,   z,   z,   z,   z,   z,       /*  30- 39 */
+  z,   z,   z,   62,  z,   z,   z,   63,  52,  53,      /*  40- 49 */
+  54,  55,  56,  57,  58,  59,  60,  61,  z,   z,       /*  50- 59 */
+  z,   z,   z,   z,   z,   0,   1,   2,   3,   4,       /*  60- 69 */
+  5,   6,   7,   8,   9,   10,  11,  12,  13,  14,      /*  70- 79 */
+  15,  16,  17,  18,  19,  20,  21,  22,  23,  24,      /*  80- 89 */
+  25,  z,   z,   z,   z,   z,   z,   26,  27,  28,      /*  90- 99 */
+  29,  30,  31,  32,  33,  34,  35,  36,  37,  38,      /* 100-109 */
+  39,  40,  41,  42,  43,  44,  45,  46,  47,  48,      /* 110-119 */
+  49,  50,  51,  z,   z,   z,   z,   z                  /* 120-127 */
 };
 #undef z
 
@@ -58,17 +58,17 @@ short base64_char_to_value[128] =
    get transformed into eight Base64 characters.  It helps understanding
    shifts and masks in the transformation functions.
 
-		 .--------.  .--------.  .--------.
-		 |aaaaaabb|  |bbbbcccc|  |ccdddddd|
-		 `--------'  `--------'  `--------'
+                 .--------.  .--------.  .--------.
+                 |aaaaaabb|  |bbbbcccc|  |ccdddddd|
+                 `--------'  `--------'  `--------'
                     6   2      4   4       2   6
-	       .--------+--------+--------+--------.
-	       |00aaaaaa|00bbbbbb|00cccccc|00dddddd|
-	       `--------+--------+--------+--------'
+               .--------+--------+--------+--------.
+               |00aaaaaa|00bbbbbb|00cccccc|00dddddd|
+               `--------+--------+--------+--------'
 
-	       .--------+--------+--------+--------.
-	       |AAAAAAAA|BBBBBBBB|CCCCCCCC|DDDDDDDD|
-	       `--------+--------+--------+--------'
+               .--------+--------+--------+--------.
+               |AAAAAAAA|BBBBBBBB|CCCCCCCC|DDDDDDDD|
+               `--------+--------+--------+--------'
 
    The octets are divided into 6 bit chunks, which are then encoded into
    Base64 characters.  */
@@ -85,17 +85,17 @@ transform_data_base64 (RECODE_SUBTASK subtask)
     {
       character = get_byte (subtask);
       if (character == EOF)
-	break;
+        break;
 
       /* Wrap line every 76 characters.  */
 
       if (counter < MIME_LINE_LENGTH / 4)
-	counter++;
+        counter++;
       else
-	{
-	  put_byte ('\n', subtask);
-	  counter = 1;
-	}
+        {
+          put_byte ('\n', subtask);
+          counter = 1;
+        }
 
       /* Process first byte of a triplet.  */
 
@@ -106,27 +106,27 @@ transform_data_base64 (RECODE_SUBTASK subtask)
 
       character = get_byte (subtask);
       if (character == EOF)
-	{
-	  put_byte (base64_value_to_char[value], subtask);
-	  put_byte ('=', subtask);
-	  put_byte ('=', subtask);
-	  break;
-	}
+        {
+          put_byte (base64_value_to_char[value], subtask);
+          put_byte ('=', subtask);
+          put_byte ('=', subtask);
+          break;
+        }
       put_byte (base64_value_to_char[value | (BIT_MASK (4) & character >> 4)],
-		subtask);
+                subtask);
       value = (BIT_MASK (4) & character) << 2;
 
       /* Process third byte of a triplet.  */
 
       character = get_byte (subtask);
       if (character == EOF)
-	{
-	  put_byte (base64_value_to_char[value], subtask);
-	  put_byte ('=', subtask);
-	  break;
-	}
+        {
+          put_byte (base64_value_to_char[value], subtask);
+          put_byte ('=', subtask);
+          break;
+        }
       put_byte (base64_value_to_char[value | (BIT_MASK (2) & character >> 6)],
-		subtask);
+                subtask);
       put_byte (base64_value_to_char[BIT_MASK (6) & character], subtask);
     }
 
@@ -153,51 +153,51 @@ transform_base64_data (RECODE_SUBTASK subtask)
 
     top:
       if (character == EOF)
-	SUBTASK_RETURN (subtask);
+        SUBTASK_RETURN (subtask);
 
       if (character == '\n')
-	{
+        {
           character = get_byte (subtask);
-	  if (character == EOF)
+          if (character == EOF)
             SUBTASK_RETURN (subtask);
-	  if (counter != MIME_LINE_LENGTH / 4)
-	    RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
-	  counter = 0;
-	  goto top;
-	}
+          if (counter != MIME_LINE_LENGTH / 4)
+            RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
+          counter = 0;
+          goto top;
+        }
 
       if (character == '\r')
-	{
-	  RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
-	  counter = 0;
-	  continue;
-	}
+        {
+          RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
+          counter = 0;
+          continue;
+        }
 
       /* Process first byte of a quadruplet.  */
 
       counter++;
 
       if (IS_BASE64 (character))
-	value = base64_char_to_value[character] << 18;
+        value = base64_char_to_value[character] << 18;
       else
-	{
-	  RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-	  value = 0;
-	}
+        {
+          RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+          value = 0;
+        }
 
       /* Process second byte of a quadruplet.  */
 
       character = get_byte (subtask);
       if (character == EOF)
-	{
-	  RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-	  SUBTASK_RETURN (subtask);
-	}
+        {
+          RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+          SUBTASK_RETURN (subtask);
+        }
 
       if (IS_BASE64 (character))
-	value |= base64_char_to_value[character] << 12;
+        value |= base64_char_to_value[character] << 12;
       else
-	RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+        RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
 
       put_byte (value >> 16, subtask);
 
@@ -205,23 +205,23 @@ transform_base64_data (RECODE_SUBTASK subtask)
 
       character = get_byte (subtask);
       if (character == EOF)
-	{
-	  RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-	  SUBTASK_RETURN (subtask);
-	}
+        {
+          RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+          SUBTASK_RETURN (subtask);
+        }
 
       if (character == '=')
-	{
-	  character = get_byte (subtask);
-	  if (character != '=')
-	    RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-	  continue;
-	}
+        {
+          character = get_byte (subtask);
+          if (character != '=')
+            RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+          continue;
+        }
 
       if (IS_BASE64 (character))
-	value |= base64_char_to_value[character] << 6;
+        value |= base64_char_to_value[character] << 6;
       else
-	RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+        RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
 
       put_byte (BIT_MASK (8) & value >> 8, subtask);
 
@@ -229,18 +229,18 @@ transform_base64_data (RECODE_SUBTASK subtask)
 
       character = get_byte (subtask);
       if (character == EOF)
-	{
-	  RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-	  SUBTASK_RETURN (subtask);
-	}
+        {
+          RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+          SUBTASK_RETURN (subtask);
+        }
 
       if (character == '=')
-	continue;
+        continue;
 
       if (IS_BASE64 (character))
-	value |= base64_char_to_value[character];
+        value |= base64_char_to_value[character];
       else
-	RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+        RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
 
       put_byte (BIT_MASK (8) & value, subtask);
     }
@@ -251,11 +251,11 @@ module_base64 (RECODE_OUTER outer)
 {
   return
     declare_single (outer, "data", "Base64",
-		    outer->quality_variable_to_variable,
-		    NULL, transform_data_base64)
+                    outer->quality_variable_to_variable,
+                    NULL, transform_data_base64)
     && declare_single (outer, "Base64", "data",
-		       outer->quality_variable_to_variable,
-		       NULL, transform_base64_data)
+                       outer->quality_variable_to_variable,
+                       NULL, transform_base64_data)
     && declare_alias (outer, "b64", "Base64")
     && declare_alias (outer, "64", "Base64");
 }

--- a/src/btexlat1.l
+++ b/src/btexlat1.l
@@ -19,106 +19,106 @@
 
 /* Step name: bibtex_latin1.  */
 
-Letter			[a-zA-Z]
-Braces			[ \t]*(\{\})?
+Letter                  [a-zA-Z]
+Braces                  [ \t]*(\{\})?
 
 %%
 
-\\"#"				{ PUT_NON_DIACRITIC_BYTE ('#', subtask); }
-\\"$"				{ PUT_NON_DIACRITIC_BYTE ('$', subtask); }
-\\"%"				{ PUT_NON_DIACRITIC_BYTE ('%', subtask); }
-\\"&"				{ PUT_NON_DIACRITIC_BYTE ('&', subtask); }
-\\"_"				{ PUT_NON_DIACRITIC_BYTE ('_', subtask); }
-\\"{"				{ PUT_NON_DIACRITIC_BYTE ('{', subtask); }
-\\"}"				{ PUT_NON_DIACRITIC_BYTE ('}', subtask); }
+\\"#"                           { PUT_NON_DIACRITIC_BYTE ('#', subtask); }
+\\"$"                           { PUT_NON_DIACRITIC_BYTE ('$', subtask); }
+\\"%"                           { PUT_NON_DIACRITIC_BYTE ('%', subtask); }
+\\"&"                           { PUT_NON_DIACRITIC_BYTE ('&', subtask); }
+\\"_"                           { PUT_NON_DIACRITIC_BYTE ('_', subtask); }
+\\"{"                           { PUT_NON_DIACRITIC_BYTE ('{', subtask); }
+\\"}"                           { PUT_NON_DIACRITIC_BYTE ('}', subtask); }
 
-\\backslash{Braces}		{ PUT_NON_DIACRITIC_BYTE ('\\', subtask); }
+\\backslash{Braces}             { PUT_NON_DIACRITIC_BYTE ('\\', subtask); }
 
-"~"				{ PUT_NON_DIACRITIC_BYTE (160, subtask); }
-"!`"				{ PUT_NON_DIACRITIC_BYTE (161, subtask); }
-\\pound{Braces}			{ PUT_NON_DIACRITIC_BYTE (163, subtask); }
-\\S{Braces}			{ PUT_NON_DIACRITIC_BYTE (167, subtask); }
-\\\"				{ PUT_NON_DIACRITIC_BYTE (168, subtask); }
-\\copyright{Braces}		{ PUT_NON_DIACRITIC_BYTE (169, subtask); }
-"``"				{ PUT_NON_DIACRITIC_BYTE (171, subtask); }
-\\neg{Braces}			{ PUT_NON_DIACRITIC_BYTE (172, subtask); }
-\\"-"				{ PUT_NON_DIACRITIC_BYTE (173, subtask); }
-\\mbox"{$^\\circ$}"		{ PUT_NON_DIACRITIC_BYTE (176, subtask); }
-\\mbox"{$\\pm$}"		{ PUT_NON_DIACRITIC_BYTE (177, subtask); }
-\\mbox"{$^2$}"			{ PUT_NON_DIACRITIC_BYTE (178, subtask); }
-\\mbox"{$^3$}"			{ PUT_NON_DIACRITIC_BYTE (179, subtask); }
-\\"'"				{ PUT_NON_DIACRITIC_BYTE (180, subtask); }
-\\mbox"{$\\mu$}"		{ PUT_NON_DIACRITIC_BYTE (181, subtask); }
-\\cdotp				{ PUT_NON_DIACRITIC_BYTE (183, subtask); }
-\\","				{ PUT_NON_DIACRITIC_BYTE (184, subtask); }
-\\mbox"{$^1$}"			{ PUT_NON_DIACRITIC_BYTE (185, subtask); }
-"''"				{ PUT_NON_DIACRITIC_BYTE (187, subtask); }
-\\frac"1/4"{Braces}		{ PUT_NON_DIACRITIC_BYTE (188, subtask); }
-\\frac"1/2"{Braces}		{ PUT_NON_DIACRITIC_BYTE (189, subtask); }
-\\frac"3/4"{Braces}		{ PUT_NON_DIACRITIC_BYTE (190, subtask); }
-"?`"				{ PUT_NON_DIACRITIC_BYTE (191, subtask); }
+"~"                             { PUT_NON_DIACRITIC_BYTE (160, subtask); }
+"!`"                            { PUT_NON_DIACRITIC_BYTE (161, subtask); }
+\\pound{Braces}                 { PUT_NON_DIACRITIC_BYTE (163, subtask); }
+\\S{Braces}                     { PUT_NON_DIACRITIC_BYTE (167, subtask); }
+\\\"                            { PUT_NON_DIACRITIC_BYTE (168, subtask); }
+\\copyright{Braces}             { PUT_NON_DIACRITIC_BYTE (169, subtask); }
+"``"                            { PUT_NON_DIACRITIC_BYTE (171, subtask); }
+\\neg{Braces}                   { PUT_NON_DIACRITIC_BYTE (172, subtask); }
+\\"-"                           { PUT_NON_DIACRITIC_BYTE (173, subtask); }
+\\mbox"{$^\\circ$}"             { PUT_NON_DIACRITIC_BYTE (176, subtask); }
+\\mbox"{$\\pm$}"                { PUT_NON_DIACRITIC_BYTE (177, subtask); }
+\\mbox"{$^2$}"                  { PUT_NON_DIACRITIC_BYTE (178, subtask); }
+\\mbox"{$^3$}"                  { PUT_NON_DIACRITIC_BYTE (179, subtask); }
+\\"'"                           { PUT_NON_DIACRITIC_BYTE (180, subtask); }
+\\mbox"{$\\mu$}"                { PUT_NON_DIACRITIC_BYTE (181, subtask); }
+\\cdotp                         { PUT_NON_DIACRITIC_BYTE (183, subtask); }
+\\","                           { PUT_NON_DIACRITIC_BYTE (184, subtask); }
+\\mbox"{$^1$}"                  { PUT_NON_DIACRITIC_BYTE (185, subtask); }
+"''"                            { PUT_NON_DIACRITIC_BYTE (187, subtask); }
+\\frac"1/4"{Braces}             { PUT_NON_DIACRITIC_BYTE (188, subtask); }
+\\frac"1/2"{Braces}             { PUT_NON_DIACRITIC_BYTE (189, subtask); }
+\\frac"3/4"{Braces}             { PUT_NON_DIACRITIC_BYTE (190, subtask); }
+"?`"                            { PUT_NON_DIACRITIC_BYTE (191, subtask); }
 
-"{"(\\"`"A|\\"`{A}")"}"|\\"`"A|\\"`{A}"				{ put_byte (192, subtask); }
-"{"(\\"'"A|\\"'{A}")"}"|\\"'"A|\\"'{A}"				{ put_byte (193, subtask); }
-"{"(\\"^"A|\\"^{A}")"}"|\\"^"A|\\"^{A}"				{ put_byte (194, subtask); }
-"{"(\\"~"A|\\"~{A}")"}"|\\"~"A|\\"~{A}"				{ put_byte (195, subtask); }
-"{"(\\\"A|\\\""{A}")"}"|\\\"A|\\\""{A}"				{ put_byte (196, subtask); }
-"{"(\\AA{Braces})"}"|\\AA{Braces}				{ put_byte (197, subtask); }
-"{"(\\AE{Braces})"}"|\\AE{Braces}				{ put_byte (198, subtask); }
-"{"(\\c[ \t]+C|\\c"{C}")"}"|\\c[ \t]+C|\\c"{C}"			{ put_byte (199, subtask); }
-"{"(\\"`"E|\\"`{E}")"}"|\\"`"E|\\"`{E}"				{ put_byte (200, subtask); }
-"{"(\\"'"E|\\"'{E}")"}"|\\"'"E|\\"'{E}"				{ put_byte (201, subtask); }
-"{"(\\"^"E|\\"^{E}")"}"|\\"^"E|\\"^{E}"				{ put_byte (202, subtask); }
-"{"(\\\"E|\\\""{E}")"}"|\\\"E|\\\""{E}"				{ put_byte (203, subtask); }
-"{"(\\"`"I|\\"`{I}")"}"|\\"`"I|\\"`{I}"				{ put_byte (204, subtask); }
-"{"(\\"'"I|\\"'{I}")"}"|\\"'"I|\\"'{I}"				{ put_byte (205, subtask); }
-"{"(\\"^"I|\\"^{I}")"}"|\\"^"I|\\"^{I}"				{ put_byte (206, subtask); }
-"{"(\\\"I|\\\""{I}")"}"|\\\"I|\\\""{I}"				{ put_byte (207, subtask); }
-"{"(\\"~"N|\\"~{N}")"}"|\\"~"N|\\"~{N}"				{ put_byte (209, subtask); }
-"{"(\\"`"O|\\"`{O}")"}"|\\"`"O|\\"`{O}"				{ put_byte (210, subtask); }
-"{"(\\"'"O|\\"'{O}")"}"|\\"'"O|\\"'{O}"				{ put_byte (211, subtask); }
-"{"(\\"^"O|\\"^{O}")"}"|\\"^"O|\\"^{O}"				{ put_byte (212, subtask); }
-"{"(\\"~"O|\\"~{O}")"}"|\\"~"O|\\"~{O}"				{ put_byte (213, subtask); }
-"{"(\\\"O|\\\""{O}")"}"|\\\"O|\\\""{O}"				{ put_byte (214, subtask); }
-"{"(\\O{Braces})"}"|\\O{Braces}					{ put_byte (216, subtask); }
-"{"(\\"`"U|\\"`{U}")"}"|\\"`"U|\\"`{U}"				{ put_byte (217, subtask); }
-"{"(\\"'"U|\\"'{U}")"}"|\\"'"U|\\"'{U}"				{ put_byte (218, subtask); }
-"{"(\\"^"U|\\"^{U}")"}"|\\"^"U|\\"^{U}"				{ put_byte (219, subtask); }
-"{"(\\\"U|\\\""{U}")"}"|\\\"U|\\\""{U}"				{ put_byte (220, subtask); }
-"{"(\\"'"Y|\\"'{Y}")"}"|\\"'"Y|\\"'{Y}"				{ put_byte (221, subtask); }
-"{"(\\ss{Braces})"}"|\\ss{Braces}				{ put_byte (223, subtask); }
-"{"(\\"`"a|\\"`{a}")"}"|\\"`"a|\\"`{a}"				{ put_byte (224, subtask); }
-"{"(\\"'"a|\\"'{a}")"}"|\\"'"a|\\"'{a}"				{ put_byte (225, subtask); }
-"{"(\\"^"a|\\"^{a}")"}"|\\"^"a|\\"^{a}"				{ put_byte (226, subtask); }
-"{"(\\"~"a|\\"~{a}")"}"|\\"~"a|\\"~{a}"				{ put_byte (227, subtask); }
-"{"(\\\"a|\\\""{a}")"}"|\\\"a|\\\""{a}"				{ put_byte (228, subtask); }
-"{"(\\aa{Braces})"}"|\\aa{Braces}				{ put_byte (229, subtask); }
-"{"(\\ae{Braces})"}"|\\ae{Braces}				{ put_byte (230, subtask); }
-"{"(\\c[ \t]+c|\\c"{c}")"}"|\\c[ \t]+c|\\c"{c}"			{ put_byte (231, subtask); }
-"{"(\\"`"e|\\"`{e}")"}"|\\"`"e|\\"`{e}"				{ put_byte (232, subtask); }
-"{"(\\"'"e|\\"'{e}")"}"|\\"'"e|\\"'{e}"				{ put_byte (233, subtask); }
-"{"(\\"^"e|\\"^{e}")"}"|\\"^"e|\\"^{e}"				{ put_byte (234, subtask); }
-"{"(\\\"e|\\\""{e}")"}"|\\\"e|\\\""{e}"				{ put_byte (235, subtask); }
-"{"(\\"`"\\i{Braces}|\\"`{\\i}")"}"|\\"`"\\i{Braces}|\\"`{\\i}"	{ put_byte (236, subtask); }
-"{"(\\"'"\\i{Braces}|\\"'{\\i}")"}"|\\"'"\\i{Braces}|\\"'{\\i}"	{ put_byte (237, subtask); }
-"{"(\\"^"\\i{Braces}|\\"^{\\i}")"}"|\\"^"\\i{Braces}|\\"^{\\i}"	{ put_byte (238, subtask); }
-"{"(\\\"\\i{Braces}|\\\""{\\i}")"}"|\\\"\\i{Braces}|\\\""{\\i}"	{ put_byte (239, subtask); }
-"{"(\\"~"n|\\"~{n}")"}"|\\"~"n|\\"~{n}"				{ put_byte (241, subtask); }
-"{"(\\"`"o|\\"`{o}")"}"|\\"`"o|\\"`{o}"				{ put_byte (242, subtask); }
-"{"(\\"'"o|\\"'{o}")"}"|\\"'"o|\\"'{o}"				{ put_byte (243, subtask); }
-"{"(\\"^"o|\\"^{o}")"}"|\\"^"o|\\"^{o}"				{ put_byte (244, subtask); }
-"{"(\\"~"o|\\"~{o}")"}"|\\"~"o|\\"~{o}"				{ put_byte (245, subtask); }
-"{"(\\\"o|\\\""{o}")"}"|\\\"o|\\\""{o}"				{ put_byte (246, subtask); }
-"{"(\\o{Braces})"}"|\\o{Braces}					{ put_byte (248, subtask); }
-"{"(\\"`"u|\\"`{u}")"}"|\\"`"u|\\"`{u}"				{ put_byte (249, subtask); }
-"{"(\\"'"u|\\"'{u}")"}"|\\"'"u|\\"'{u}"				{ put_byte (250, subtask); }
-"{"(\\"^"u|\\"^{u}")"}"|\\"^"u|\\"^{u}"				{ put_byte (251, subtask); }
-"{"(\\\"u|\\\""{u}")"}"|\\\"u|\\\""{u}"				{ put_byte (252, subtask); }
-"{"(\\"'"y|\\"'{y}")"}"|\\"'"y|\\"'{y}"				{ put_byte (253, subtask); }
-"{"(\\\"y|\\\""{y}")"}"|\\\"y|\\\""{y}"				{ put_byte (255, subtask); }
+"{"(\\"`"A|\\"`{A}")"}"|\\"`"A|\\"`{A}"                         { put_byte (192, subtask); }
+"{"(\\"'"A|\\"'{A}")"}"|\\"'"A|\\"'{A}"                         { put_byte (193, subtask); }
+"{"(\\"^"A|\\"^{A}")"}"|\\"^"A|\\"^{A}"                         { put_byte (194, subtask); }
+"{"(\\"~"A|\\"~{A}")"}"|\\"~"A|\\"~{A}"                         { put_byte (195, subtask); }
+"{"(\\\"A|\\\""{A}")"}"|\\\"A|\\\""{A}"                         { put_byte (196, subtask); }
+"{"(\\AA{Braces})"}"|\\AA{Braces}                               { put_byte (197, subtask); }
+"{"(\\AE{Braces})"}"|\\AE{Braces}                               { put_byte (198, subtask); }
+"{"(\\c[ \t]+C|\\c"{C}")"}"|\\c[ \t]+C|\\c"{C}"                 { put_byte (199, subtask); }
+"{"(\\"`"E|\\"`{E}")"}"|\\"`"E|\\"`{E}"                         { put_byte (200, subtask); }
+"{"(\\"'"E|\\"'{E}")"}"|\\"'"E|\\"'{E}"                         { put_byte (201, subtask); }
+"{"(\\"^"E|\\"^{E}")"}"|\\"^"E|\\"^{E}"                         { put_byte (202, subtask); }
+"{"(\\\"E|\\\""{E}")"}"|\\\"E|\\\""{E}"                         { put_byte (203, subtask); }
+"{"(\\"`"I|\\"`{I}")"}"|\\"`"I|\\"`{I}"                         { put_byte (204, subtask); }
+"{"(\\"'"I|\\"'{I}")"}"|\\"'"I|\\"'{I}"                         { put_byte (205, subtask); }
+"{"(\\"^"I|\\"^{I}")"}"|\\"^"I|\\"^{I}"                         { put_byte (206, subtask); }
+"{"(\\\"I|\\\""{I}")"}"|\\\"I|\\\""{I}"                         { put_byte (207, subtask); }
+"{"(\\"~"N|\\"~{N}")"}"|\\"~"N|\\"~{N}"                         { put_byte (209, subtask); }
+"{"(\\"`"O|\\"`{O}")"}"|\\"`"O|\\"`{O}"                         { put_byte (210, subtask); }
+"{"(\\"'"O|\\"'{O}")"}"|\\"'"O|\\"'{O}"                         { put_byte (211, subtask); }
+"{"(\\"^"O|\\"^{O}")"}"|\\"^"O|\\"^{O}"                         { put_byte (212, subtask); }
+"{"(\\"~"O|\\"~{O}")"}"|\\"~"O|\\"~{O}"                         { put_byte (213, subtask); }
+"{"(\\\"O|\\\""{O}")"}"|\\\"O|\\\""{O}"                         { put_byte (214, subtask); }
+"{"(\\O{Braces})"}"|\\O{Braces}                                 { put_byte (216, subtask); }
+"{"(\\"`"U|\\"`{U}")"}"|\\"`"U|\\"`{U}"                         { put_byte (217, subtask); }
+"{"(\\"'"U|\\"'{U}")"}"|\\"'"U|\\"'{U}"                         { put_byte (218, subtask); }
+"{"(\\"^"U|\\"^{U}")"}"|\\"^"U|\\"^{U}"                         { put_byte (219, subtask); }
+"{"(\\\"U|\\\""{U}")"}"|\\\"U|\\\""{U}"                         { put_byte (220, subtask); }
+"{"(\\"'"Y|\\"'{Y}")"}"|\\"'"Y|\\"'{Y}"                         { put_byte (221, subtask); }
+"{"(\\ss{Braces})"}"|\\ss{Braces}                               { put_byte (223, subtask); }
+"{"(\\"`"a|\\"`{a}")"}"|\\"`"a|\\"`{a}"                         { put_byte (224, subtask); }
+"{"(\\"'"a|\\"'{a}")"}"|\\"'"a|\\"'{a}"                         { put_byte (225, subtask); }
+"{"(\\"^"a|\\"^{a}")"}"|\\"^"a|\\"^{a}"                         { put_byte (226, subtask); }
+"{"(\\"~"a|\\"~{a}")"}"|\\"~"a|\\"~{a}"                         { put_byte (227, subtask); }
+"{"(\\\"a|\\\""{a}")"}"|\\\"a|\\\""{a}"                         { put_byte (228, subtask); }
+"{"(\\aa{Braces})"}"|\\aa{Braces}                               { put_byte (229, subtask); }
+"{"(\\ae{Braces})"}"|\\ae{Braces}                               { put_byte (230, subtask); }
+"{"(\\c[ \t]+c|\\c"{c}")"}"|\\c[ \t]+c|\\c"{c}"                 { put_byte (231, subtask); }
+"{"(\\"`"e|\\"`{e}")"}"|\\"`"e|\\"`{e}"                         { put_byte (232, subtask); }
+"{"(\\"'"e|\\"'{e}")"}"|\\"'"e|\\"'{e}"                         { put_byte (233, subtask); }
+"{"(\\"^"e|\\"^{e}")"}"|\\"^"e|\\"^{e}"                         { put_byte (234, subtask); }
+"{"(\\\"e|\\\""{e}")"}"|\\\"e|\\\""{e}"                         { put_byte (235, subtask); }
+"{"(\\"`"\\i{Braces}|\\"`{\\i}")"}"|\\"`"\\i{Braces}|\\"`{\\i}" { put_byte (236, subtask); }
+"{"(\\"'"\\i{Braces}|\\"'{\\i}")"}"|\\"'"\\i{Braces}|\\"'{\\i}" { put_byte (237, subtask); }
+"{"(\\"^"\\i{Braces}|\\"^{\\i}")"}"|\\"^"\\i{Braces}|\\"^{\\i}" { put_byte (238, subtask); }
+"{"(\\\"\\i{Braces}|\\\""{\\i}")"}"|\\\"\\i{Braces}|\\\""{\\i}" { put_byte (239, subtask); }
+"{"(\\"~"n|\\"~{n}")"}"|\\"~"n|\\"~{n}"                         { put_byte (241, subtask); }
+"{"(\\"`"o|\\"`{o}")"}"|\\"`"o|\\"`{o}"                         { put_byte (242, subtask); }
+"{"(\\"'"o|\\"'{o}")"}"|\\"'"o|\\"'{o}"                         { put_byte (243, subtask); }
+"{"(\\"^"o|\\"^{o}")"}"|\\"^"o|\\"^{o}"                         { put_byte (244, subtask); }
+"{"(\\"~"o|\\"~{o}")"}"|\\"~"o|\\"~{o}"                         { put_byte (245, subtask); }
+"{"(\\\"o|\\\""{o}")"}"|\\\"o|\\\""{o}"                         { put_byte (246, subtask); }
+"{"(\\o{Braces})"}"|\\o{Braces}                                 { put_byte (248, subtask); }
+"{"(\\"`"u|\\"`{u}")"}"|\\"`"u|\\"`{u}"                         { put_byte (249, subtask); }
+"{"(\\"'"u|\\"'{u}")"}"|\\"'"u|\\"'{u}"                         { put_byte (250, subtask); }
+"{"(\\"^"u|\\"^{u}")"}"|\\"^"u|\\"^{u}"                         { put_byte (251, subtask); }
+"{"(\\\"u|\\\""{u}")"}"|\\\"u|\\\""{u}"                         { put_byte (252, subtask); }
+"{"(\\"'"y|\\"'{y}")"}"|\\"'"y|\\"'{y}"                         { put_byte (253, subtask); }
+"{"(\\\"y|\\\""{y}")"}"|\\\"y|\\\""{y}"                         { put_byte (255, subtask); }
 
-\\[`'^"]\\i{Letter}*{Braces}	{ ECHO; }
-\\{Letter}+{Braces}		{ ECHO; }
+\\[`'^"]\\i{Letter}*{Braces}    { ECHO; }
+\\{Letter}+{Braces}             { ECHO; }
 
 %%
 

--- a/src/cdcnos.c
+++ b/src/cdcnos.c
@@ -23,141 +23,141 @@
 
 static const char *const translation_table[128] =
   {
-    "^5",			/*   0 */
-    "^6",			/*   1 */
-    "^7",			/*   2 */
-    "^8",			/*   3 */
-    "^9",			/*   4 */
-    "^+",			/*   5 */
-    "^-",			/*   6 */
-    "^*",			/*   7 */
-    "^/",			/*   8 */
-    "^(",			/*   9 */
-    "\n",			/*  10, would have been "^)" */
-    "^$",			/*  11 */
-    "^=",			/*  12 */
-    "^ ",			/*  13 */
-    "^,",			/*  14 */
-    "^.",			/*  15 */
-    "^#",			/*  16 */
-    "^[",			/*  17 */
-    "^]",			/*  18 */
-    "^%",			/*  19 */
-    "^\"",			/*  20 */
-    "^_",			/*  21 */
-    "^!",			/*  22 */
-    "^&",			/*  23 */
-    "^'",			/*  24 */
-    "^?",			/*  25 */
-    "^<",			/*  26 */
-    "^>",			/*  27 */
-    "^@",			/*  28 */
-    "^\\",			/*  29 */
-    "^^",			/*  30 */
-    "^;",			/*  31 */
-    " ",			/*  32 */
-    "!",			/*  33 */
-    "\"",			/*  34 */
-    "#",			/*  35 */
-    "$",			/*  36 */
-    "%",			/*  37 */
-    "&",			/*  38 */
-    "'",			/*  39 */
-    "(",			/*  40 */
-    ")",			/*  41 */
-    "*",			/*  42 */
-    "+",			/*  43 */
-    ",",			/*  44 */
-    "-",			/*  45 */
-    ".",			/*  46 */
-    "/",			/*  47 */
-    "0",			/*  48 */
-    "1",			/*  49 */
-    "2",			/*  50 */
-    "3",			/*  51 */
-    "4",			/*  52 */
-    "5",			/*  53 */
-    "6",			/*  54 */
-    "7",			/*  55 */
-    "8",			/*  56 */
-    "9",			/*  57 */
-    "@D",			/*  58 */
-    ";",			/*  59 */
-    "<",			/*  60 */
-    "=",			/*  61 */
-    ">",			/*  62 */
-    "?",			/*  63 */
-    "@A",			/*  64 */
-    "A",			/*  65 */
-    "B",			/*  66 */
-    "C",			/*  67 */
-    "D",			/*  68 */
-    "E",			/*  69 */
-    "F",			/*  70 */
-    "G",			/*  71 */
-    "H",			/*  72 */
-    "I",			/*  73 */
-    "J",			/*  74 */
-    "K",			/*  75 */
-    "L",			/*  76 */
-    "M",			/*  77 */
-    "N",			/*  78 */
-    "O",			/*  79 */
-    "P",			/*  80 */
-    "Q",			/*  81 */
-    "R",			/*  82 */
-    "S",			/*  83 */
-    "T",			/*  84 */
-    "U",			/*  85 */
-    "V",			/*  86 */
-    "W",			/*  87 */
-    "X",			/*  88 */
-    "Y",			/*  89 */
-    "Z",			/*  90 */
-    "[",			/*  91 */
-    "\\",			/*  92 */
-    "]",			/*  93 */
-    "@B",			/*  94 */
-    "_",			/*  95 */
-    "@G",			/*  96 */
-    "^A",			/*  97 */
-    "^B",			/*  98 */
-    "^C",			/*  99 */
-    "^D",			/* 100 */
-    "^E",			/* 101 */
-    "^F",			/* 102 */
-    "^G",			/* 103 */
-    "^H",			/* 104 */
-    "^I",			/* 105 */
-    "^J",			/* 106 */
-    "^K",			/* 107 */
-    "^L",			/* 108 */
-    "^M",			/* 109 */
-    "^N",			/* 110 */
-    "^O",			/* 111 */
-    "^P",			/* 112 */
-    "^Q",			/* 113 */
-    "^R",			/* 114 */
-    "^S",			/* 115 */
-    "^T",			/* 116 */
-    "^U",			/* 117 */
-    "^V",			/* 118 */
-    "^W",			/* 119 */
-    "^X",			/* 120 */
-    "^Y",			/* 121 */
-    "^Z",			/* 122 */
-    "^0",			/* 123 */
-    "^1",			/* 124 */
-    "^2",			/* 125 */
-    "^3",			/* 126 */
-    "^4",			/* 127 */
+    "^5",                       /*   0 */
+    "^6",                       /*   1 */
+    "^7",                       /*   2 */
+    "^8",                       /*   3 */
+    "^9",                       /*   4 */
+    "^+",                       /*   5 */
+    "^-",                       /*   6 */
+    "^*",                       /*   7 */
+    "^/",                       /*   8 */
+    "^(",                       /*   9 */
+    "\n",                       /*  10, would have been "^)" */
+    "^$",                       /*  11 */
+    "^=",                       /*  12 */
+    "^ ",                       /*  13 */
+    "^,",                       /*  14 */
+    "^.",                       /*  15 */
+    "^#",                       /*  16 */
+    "^[",                       /*  17 */
+    "^]",                       /*  18 */
+    "^%",                       /*  19 */
+    "^\"",                      /*  20 */
+    "^_",                       /*  21 */
+    "^!",                       /*  22 */
+    "^&",                       /*  23 */
+    "^'",                       /*  24 */
+    "^?",                       /*  25 */
+    "^<",                       /*  26 */
+    "^>",                       /*  27 */
+    "^@",                       /*  28 */
+    "^\\",                      /*  29 */
+    "^^",                       /*  30 */
+    "^;",                       /*  31 */
+    " ",                        /*  32 */
+    "!",                        /*  33 */
+    "\"",                       /*  34 */
+    "#",                        /*  35 */
+    "$",                        /*  36 */
+    "%",                        /*  37 */
+    "&",                        /*  38 */
+    "'",                        /*  39 */
+    "(",                        /*  40 */
+    ")",                        /*  41 */
+    "*",                        /*  42 */
+    "+",                        /*  43 */
+    ",",                        /*  44 */
+    "-",                        /*  45 */
+    ".",                        /*  46 */
+    "/",                        /*  47 */
+    "0",                        /*  48 */
+    "1",                        /*  49 */
+    "2",                        /*  50 */
+    "3",                        /*  51 */
+    "4",                        /*  52 */
+    "5",                        /*  53 */
+    "6",                        /*  54 */
+    "7",                        /*  55 */
+    "8",                        /*  56 */
+    "9",                        /*  57 */
+    "@D",                       /*  58 */
+    ";",                        /*  59 */
+    "<",                        /*  60 */
+    "=",                        /*  61 */
+    ">",                        /*  62 */
+    "?",                        /*  63 */
+    "@A",                       /*  64 */
+    "A",                        /*  65 */
+    "B",                        /*  66 */
+    "C",                        /*  67 */
+    "D",                        /*  68 */
+    "E",                        /*  69 */
+    "F",                        /*  70 */
+    "G",                        /*  71 */
+    "H",                        /*  72 */
+    "I",                        /*  73 */
+    "J",                        /*  74 */
+    "K",                        /*  75 */
+    "L",                        /*  76 */
+    "M",                        /*  77 */
+    "N",                        /*  78 */
+    "O",                        /*  79 */
+    "P",                        /*  80 */
+    "Q",                        /*  81 */
+    "R",                        /*  82 */
+    "S",                        /*  83 */
+    "T",                        /*  84 */
+    "U",                        /*  85 */
+    "V",                        /*  86 */
+    "W",                        /*  87 */
+    "X",                        /*  88 */
+    "Y",                        /*  89 */
+    "Z",                        /*  90 */
+    "[",                        /*  91 */
+    "\\",                       /*  92 */
+    "]",                        /*  93 */
+    "@B",                       /*  94 */
+    "_",                        /*  95 */
+    "@G",                       /*  96 */
+    "^A",                       /*  97 */
+    "^B",                       /*  98 */
+    "^C",                       /*  99 */
+    "^D",                       /* 100 */
+    "^E",                       /* 101 */
+    "^F",                       /* 102 */
+    "^G",                       /* 103 */
+    "^H",                       /* 104 */
+    "^I",                       /* 105 */
+    "^J",                       /* 106 */
+    "^K",                       /* 107 */
+    "^L",                       /* 108 */
+    "^M",                       /* 109 */
+    "^N",                       /* 110 */
+    "^O",                       /* 111 */
+    "^P",                       /* 112 */
+    "^Q",                       /* 113 */
+    "^R",                       /* 114 */
+    "^S",                       /* 115 */
+    "^T",                       /* 116 */
+    "^U",                       /* 117 */
+    "^V",                       /* 118 */
+    "^W",                       /* 119 */
+    "^X",                       /* 120 */
+    "^Y",                       /* 121 */
+    "^Z",                       /* 122 */
+    "^0",                       /* 123 */
+    "^1",                       /* 124 */
+    "^2",                       /* 125 */
+    "^3",                       /* 126 */
+    "^4",                       /* 127 */
   };
 
 static bool
 init_ascii_cdcnos (RECODE_STEP step,
-		   RECODE_CONST_REQUEST request,
-		   RECODE_CONST_OPTION_LIST before_options,
-		   RECODE_CONST_OPTION_LIST after_options)
+                   RECODE_CONST_REQUEST request,
+                   RECODE_CONST_OPTION_LIST before_options,
+                   RECODE_CONST_OPTION_LIST after_options)
 {
   RECODE_OUTER outer = request->outer;
   const char **table;
@@ -181,145 +181,145 @@ init_ascii_cdcnos (RECODE_STEP step,
 
 /* Previous obsolete lex code:
 
-@A			{ put_byte ('@', subtask); }
-@B			{ put_byte ('^', subtask); }
-@D			{ put_byte (':', subtask); }
-@G			{ put_byte ('`', subtask); }
+@A                      { put_byte ('@', subtask); }
+@B                      { put_byte ('^', subtask); }
+@D                      { put_byte (':', subtask); }
+@G                      { put_byte ('`', subtask); }
 
-\^" "			{ put_byte ( 13, subtask); }
-\^!			{ put_byte ( 22, subtask); }
-\^\"			{ put_byte ( 20, subtask); }
-\^#			{ put_byte ( 16, subtask); }
-\^$			{ put_byte ( 11, subtask); }
-\^\%			{ put_byte ( 19, subtask); }
-\^&			{ put_byte ( 23, subtask); }
-\^'			{ put_byte ( 24, subtask); }
-\^\(			{ put_byte (  9, subtask); }
-\^\)			{ put_byte ( 10, subtask); }
-\^\*			{ put_byte (  7, subtask); }
-\^\+			{ put_byte (  5, subtask); }
-\^\,			{ put_byte ( 14, subtask); }
-\^-			{ put_byte (  6, subtask); }
-\^\.			{ put_byte ( 15, subtask); }
-\^\/			{ put_byte (  8, subtask); }
+\^" "                   { put_byte ( 13, subtask); }
+\^!                     { put_byte ( 22, subtask); }
+\^\"                    { put_byte ( 20, subtask); }
+\^#                     { put_byte ( 16, subtask); }
+\^$                     { put_byte ( 11, subtask); }
+\^\%                    { put_byte ( 19, subtask); }
+\^&                     { put_byte ( 23, subtask); }
+\^'                     { put_byte ( 24, subtask); }
+\^\(                    { put_byte (  9, subtask); }
+\^\)                    { put_byte ( 10, subtask); }
+\^\*                    { put_byte (  7, subtask); }
+\^\+                    { put_byte (  5, subtask); }
+\^\,                    { put_byte ( 14, subtask); }
+\^-                     { put_byte (  6, subtask); }
+\^\.                    { put_byte ( 15, subtask); }
+\^\/                    { put_byte (  8, subtask); }
 
-\^0			{ put_byte ('{', subtask); }
-\^1			{ put_byte ('|', subtask); }
-\^2			{ put_byte ('}', subtask); }
-\^3			{ put_byte ('~', subtask); }
-\^4			{ put_byte (127, subtask); }
+\^0                     { put_byte ('{', subtask); }
+\^1                     { put_byte ('|', subtask); }
+\^2                     { put_byte ('}', subtask); }
+\^3                     { put_byte ('~', subtask); }
+\^4                     { put_byte (127, subtask); }
 
-\^5			{ put_byte (  0, subtask); }
-\^6			{ put_byte (  1, subtask); }
-\^7			{ put_byte (  2, subtask); }
-\^8			{ put_byte (  3, subtask); }
-\^9			{ put_byte (  4, subtask); }
+\^5                     { put_byte (  0, subtask); }
+\^6                     { put_byte (  1, subtask); }
+\^7                     { put_byte (  2, subtask); }
+\^8                     { put_byte (  3, subtask); }
+\^9                     { put_byte (  4, subtask); }
 
-\^;			{ put_byte ( 31, subtask); }
-\^<			{ put_byte ( 26, subtask); }
-\^=			{ put_byte ( 12, subtask); }
-\^>			{ put_byte ( 27, subtask); }
-\^?			{ put_byte ( 25, subtask); }
-\^@			{ put_byte ( 28, subtask); }
+\^;                     { put_byte ( 31, subtask); }
+\^<                     { put_byte ( 26, subtask); }
+\^=                     { put_byte ( 12, subtask); }
+\^>                     { put_byte ( 27, subtask); }
+\^?                     { put_byte ( 25, subtask); }
+\^@                     { put_byte ( 28, subtask); }
 
-\^[A-Z]			{ put_byte (yytext[1]-'A'+'a', subtask); }
+\^[A-Z]                 { put_byte (yytext[1]-'A'+'a', subtask); }
 
-\^\[			{ put_byte ( 17, subtask); }
-\^\\			{ put_byte ( 29, subtask); }
-\^]			{ put_byte ( 18, subtask); }
-\^\^			{ put_byte ( 30, subtask); }
-\^_			{ put_byte ( 21, subtask); }
+\^\[                    { put_byte ( 17, subtask); }
+\^\\                    { put_byte ( 29, subtask); }
+\^]                     { put_byte ( 18, subtask); }
+\^\^                    { put_byte ( 30, subtask); }
+\^_                     { put_byte ( 21, subtask); }
 
-\^[a-z]			{ put_byte (yytext[1], subtask); }
+\^[a-z]                 { put_byte (yytext[1], subtask); }
 
 */
 
 static bool
 transform_cdcnos_ascii (RECODE_SUBTASK subtask)
 {
-  int input_char;		/* current character */
+  int input_char;               /* current character */
 
   while (input_char = get_byte (subtask), input_char != EOF)
     {
       switch (input_char)
-	{
+        {
         case '@':
-	  switch (input_char = get_byte (subtask), input_char)
-	    {
-	    case 'A': case 'a': input_char = '@'; break;
-	    case 'B': case 'b': input_char = '^'; break;
-	    case 'D': case 'd': input_char = ':'; break;
-	    case 'G': case 'g': input_char = '`'; break;
+          switch (input_char = get_byte (subtask), input_char)
+            {
+            case 'A': case 'a': input_char = '@'; break;
+            case 'B': case 'b': input_char = '^'; break;
+            case 'D': case 'd': input_char = ':'; break;
+            case 'G': case 'g': input_char = '`'; break;
 
-	    default:
-	      RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-	      put_byte ('@', subtask);
-	      if (input_char == EOF)
-		SUBTASK_RETURN (subtask);
-	    }
-	  break;
+            default:
+              RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+              put_byte ('@', subtask);
+              if (input_char == EOF)
+                SUBTASK_RETURN (subtask);
+            }
+          break;
 
-	case '^':
-	  input_char = get_byte (subtask);
-	  if (input_char >= 'A' && input_char <= 'Z')
-	    input_char += 'a' - 'A';
-	  else if (input_char < 'a' || input_char > 'z')
-	    switch (input_char)
-	      {
-	      case ' ': input_char = 13; break;
-	      case '!': input_char = 22; break;
-	      case '"': input_char = 20; break;
-	      case '#': input_char = 16; break;
-	      case '$': input_char = 11; break;
-	      case '%': input_char = 19; break;
-	      case '&': input_char = 23; break;
-	      case '\'': input_char = 24; break;
-	      case '(': input_char = 9; break;
+        case '^':
+          input_char = get_byte (subtask);
+          if (input_char >= 'A' && input_char <= 'Z')
+            input_char += 'a' - 'A';
+          else if (input_char < 'a' || input_char > 'z')
+            switch (input_char)
+              {
+              case ' ': input_char = 13; break;
+              case '!': input_char = 22; break;
+              case '"': input_char = 20; break;
+              case '#': input_char = 16; break;
+              case '$': input_char = 11; break;
+              case '%': input_char = 19; break;
+              case '&': input_char = 23; break;
+              case '\'': input_char = 24; break;
+              case '(': input_char = 9; break;
 
-	      case ')':
-		RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
-		input_char = '\n'; /* 10 */
-		break;
+              case ')':
+                RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
+                input_char = '\n'; /* 10 */
+                break;
 
-	      case '*': input_char = 7; break;
-	      case '+': input_char = 5; break;
-	      case ',': input_char = 14; break;
-	      case '-': input_char = 6; break;
-	      case '.': input_char = 15; break;
-	      case '/': input_char = 8; break;
-	      case '0': input_char = '{'; break;
-	      case '1': input_char = '|'; break;
-	      case '2': input_char = '}'; break;
-	      case '3': input_char = '~'; break;
-	      case '4': input_char = 127; break;
-	      case '5': input_char = 0; break;
-	      case '6': input_char = 1; break;
-	      case '7': input_char = 2; break;
-	      case '8': input_char = 3; break;
-	      case '9': input_char = 4; break;
-	      case ';': input_char = 31; break;
-	      case '<': input_char = 26; break;
-	      case '=': input_char = 12; break;
-	      case '>': input_char = 27; break;
-	      case '?': input_char = 25; break;
-	      case '@': input_char = 28; break;
-	      case '[': input_char = 17; break;
-	      case '\\': input_char = 29; break;
-	      case ']': input_char = 18; break;
-	      case '^': input_char = 30; break;
-	      case '_': input_char = 21; break;
+              case '*': input_char = 7; break;
+              case '+': input_char = 5; break;
+              case ',': input_char = 14; break;
+              case '-': input_char = 6; break;
+              case '.': input_char = 15; break;
+              case '/': input_char = 8; break;
+              case '0': input_char = '{'; break;
+              case '1': input_char = '|'; break;
+              case '2': input_char = '}'; break;
+              case '3': input_char = '~'; break;
+              case '4': input_char = 127; break;
+              case '5': input_char = 0; break;
+              case '6': input_char = 1; break;
+              case '7': input_char = 2; break;
+              case '8': input_char = 3; break;
+              case '9': input_char = 4; break;
+              case ';': input_char = 31; break;
+              case '<': input_char = 26; break;
+              case '=': input_char = 12; break;
+              case '>': input_char = 27; break;
+              case '?': input_char = 25; break;
+              case '@': input_char = 28; break;
+              case '[': input_char = 17; break;
+              case '\\': input_char = 29; break;
+              case ']': input_char = 18; break;
+              case '^': input_char = 30; break;
+              case '_': input_char = 21; break;
 
-	      default:
-		RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-	        put_byte ('^', subtask);
-	        if (input_char == EOF)
-		  SUBTASK_RETURN (subtask);
-	      }
-	  break;
+              default:
+                RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+                put_byte ('^', subtask);
+                if (input_char == EOF)
+                  SUBTASK_RETURN (subtask);
+              }
+          break;
 
         default:
           break;
-	}
+        }
       put_byte (input_char, subtask);
     }
   SUBTASK_RETURN (subtask);
@@ -330,11 +330,11 @@ module_cdcnos (RECODE_OUTER outer)
 {
   return
     declare_single (outer, "ASCII-BS", "CDC-NOS",
-		    outer->quality_byte_to_variable,
-		    init_ascii_cdcnos, transform_byte_to_variable)
+                    outer->quality_byte_to_variable,
+                    init_ascii_cdcnos, transform_byte_to_variable)
     && declare_single (outer, "CDC-NOS", "ASCII-BS",
-		       outer->quality_variable_to_byte,
-		       NULL, transform_cdcnos_ascii)
+                       outer->quality_variable_to_byte,
+                       NULL, transform_cdcnos_ascii)
     && declare_alias (outer, "NOS", "CDC-NOS");
 }
 

--- a/src/charname.c
+++ b/src/charname.c
@@ -23,7 +23,7 @@
 
 /*--------------------------------------------------------------------.
 | Return a statically allocated full charname associated with a given |
-| SYMBOL, or NULL if not found.					      |
+| SYMBOL, or NULL if not found.                                       |
 `--------------------------------------------------------------------*/
 
 const char *
@@ -46,11 +46,11 @@ ucs2_to_charname (int ucs2)
     {
       middle = (first + last) / 2;
       if (charname[middle].code < ucs2)
-	first = middle + 1;
+        first = middle + 1;
       else if (charname[middle].code > ucs2)
-	last = middle;
+        last = middle;
       else
-	break;
+        break;
     }
 
   /* If the UCS value has not been found, return the NULL string.  */
@@ -68,18 +68,18 @@ ucs2_to_charname (int ucs2)
 
       value = *(const unsigned char *) in - 1;
       if (value >= NUMBER_OF_SINGLES)
-	value = (NUMBER_OF_SINGLES + 255 * (value - NUMBER_OF_SINGLES)
-		 + *(const unsigned char *) ++in - 1);
+        value = (NUMBER_OF_SINGLES + 255 * (value - NUMBER_OF_SINGLES)
+                 + *(const unsigned char *) ++in - 1);
 
       /* Copy it.  */
 
       if (out)
-	*out++ = ' ';
+        *out++ = ' ';
       else
-	out = result;
+        out = result;
 
       for (cursor = word[value]; *cursor; cursor++)
-	*out++ = *cursor;
+        *out++ = *cursor;
     }
 
   /* Return the result.  */

--- a/src/combine.c
+++ b/src/combine.c
@@ -82,9 +82,9 @@ combined_compare (const void *void_first, const void *void_second)
 
 bool
 init_explode (RECODE_STEP step,
-	      RECODE_CONST_REQUEST request _GL_UNUSED,
-	      RECODE_CONST_OPTION_LIST before_options,
-	      RECODE_CONST_OPTION_LIST after_options)
+              RECODE_CONST_REQUEST request _GL_UNUSED,
+              RECODE_CONST_OPTION_LIST before_options,
+              RECODE_CONST_OPTION_LIST after_options)
 {
   const unsigned short *data = (const unsigned short *) step->step_table;
   Hash_table *table;
@@ -106,10 +106,10 @@ init_explode (RECODE_STEP step,
   while (*data != DONE)
     {
       if (!hash_insert (table, data))
-	return false;
+        return false;
 
       while (*data != DONE)
-	data++;
+        data++;
       data++;
     }
 
@@ -132,16 +132,16 @@ explode_byte_byte (RECODE_SUBTASK subtask)
       unsigned short *result = (unsigned short *) hash_lookup (table, &lookup);
 
       if (result)
-	{
-	  result++;
-	  while (*result != DONE && *result != ELSE)
-	    {
-	      put_byte (*result, subtask);
-	      result++;
-	    }
-	}
+        {
+          result++;
+          while (*result != DONE && *result != ELSE)
+            {
+              put_byte (*result, subtask);
+              result++;
+            }
+        }
       else
-	put_byte (value, subtask);
+        put_byte (value, subtask);
     }
 
   SUBTASK_RETURN (subtask);
@@ -159,16 +159,16 @@ explode_ucs2_byte (RECODE_SUBTASK subtask)
       unsigned short *result = (unsigned short *) hash_lookup (table, &lookup);
 
       if (result)
-	{
-	  result++;
-	  while (*result != DONE && *result != ELSE)
-	    {
-	      put_byte (*result, subtask);
-	      result++;
-	    }
-	}
+        {
+          result++;
+          while (*result != DONE && *result != ELSE)
+            {
+              put_byte (*result, subtask);
+              result++;
+            }
+        }
       else
-	put_byte (value, subtask);
+        put_byte (value, subtask);
     }
 
   SUBTASK_RETURN (subtask);
@@ -183,26 +183,26 @@ explode_byte_ucs2 (RECODE_SUBTASK subtask)
   if (value = get_byte (subtask), value != (unsigned)EOF)
     {
       if (subtask->task->byte_order_mark)
-	put_ucs2 (BYTE_ORDER_MARK, subtask);
+        put_ucs2 (BYTE_ORDER_MARK, subtask);
 
       while (true)
-	{
-	  unsigned short lookup = value;
-	  unsigned short *result
+        {
+          unsigned short lookup = value;
+          unsigned short *result
             = (unsigned short *) hash_lookup (table, &lookup);
 
-	  if (result)
-	    {
-	      result++;
-	      while (*result != DONE && *result != ELSE)
-		put_ucs2 (*result++, subtask);
-	    }
-	  else
-	    put_ucs2 (value, subtask);
+          if (result)
+            {
+              result++;
+              while (*result != DONE && *result != ELSE)
+                put_ucs2 (*result++, subtask);
+            }
+          else
+            put_ucs2 (value, subtask);
 
-	  if (value = get_byte (subtask), value == (unsigned)EOF)
-	    break;
-	}
+          if (value = get_byte (subtask), value == (unsigned)EOF)
+            break;
+        }
     }
 
   SUBTASK_RETURN (subtask);
@@ -217,26 +217,26 @@ explode_ucs2_ucs2 (RECODE_SUBTASK subtask)
   if (get_ucs2 (&value, subtask))
     {
       if (subtask->task->byte_order_mark)
-	put_ucs2 (BYTE_ORDER_MARK, subtask);
+        put_ucs2 (BYTE_ORDER_MARK, subtask);
 
       while (true)
-	{
-	  unsigned short lookup = value;
-	  unsigned short *result
+        {
+          unsigned short lookup = value;
+          unsigned short *result
             = (unsigned short *) hash_lookup (table, &lookup);
 
-	  if (result)
-	    {
-	      result++;
-	      while (*result != DONE && *result != ELSE)
-		put_ucs2 (*result++, subtask);
-	    }
-	  else
-	    put_ucs2 (value, subtask);
+          if (result)
+            {
+              result++;
+              while (*result != DONE && *result != ELSE)
+                put_ucs2 (*result++, subtask);
+            }
+          else
+            put_ucs2 (value, subtask);
 
-	  if (!get_ucs2 (&value, subtask))
-	    break;
-	}
+          if (!get_ucs2 (&value, subtask))
+            break;
+        }
     }
 
   SUBTASK_RETURN (subtask);
@@ -255,11 +255,11 @@ explode_ucs2_ucs2 (RECODE_SUBTASK subtask)
 
 struct state
 {
-  unsigned short character;	/* last character seen to trigger this state */
-  unsigned short result;	/* character equivalent to the combination */
-  struct state *shift;		/* list of states for one more character */
-  struct state *unshift;	/* state for one less character (back link) */
-  struct state *next;		/* next state in a linked chain of states */
+  unsigned short character;     /* last character seen to trigger this state */
+  unsigned short result;        /* character equivalent to the combination */
+  struct state *shift;          /* list of states for one more character */
+  struct state *unshift;        /* state for one less character (back link) */
+  struct state *next;           /* next state in a linked chain of states */
 };
 
 /*---------------------------.
@@ -300,20 +300,20 @@ state_free (void *void_state)
 
 static struct state *
 prepare_shifted_state (struct state *state, unsigned character,
-		       RECODE_CONST_STEP step)
+                       RECODE_CONST_STEP step)
 {
   if (state)
     {
       struct state *shift = state->shift;
 
       while (shift)
-	if (shift->character == character)
-	  return shift;
-	else
-	  shift = shift->next;
+        if (shift->character == character)
+          return shift;
+        else
+          shift = shift->next;
 
       if (shift = (struct state *) malloc (sizeof (struct state)), !shift)
-	return NULL;
+        return NULL;
 
       shift->character = character;
       shift->result = NOT_A_CHARACTER;
@@ -331,36 +331,36 @@ prepare_shifted_state (struct state *state, unsigned character,
       lookup.character = character;
       state = (struct state *) hash_lookup (table, &lookup);
       if (!state)
-	{
-	  if (state = (struct state *) malloc (sizeof (struct state)), !state)
-	    return NULL;
+        {
+          if (state = (struct state *) malloc (sizeof (struct state)), !state)
+            return NULL;
 
-	  state->character = character;
-	  state->result = character;
-	  state->shift = NULL;
-	  state->unshift = NULL;
-	  state->next = NULL;
+          state->character = character;
+          state->result = character;
+          state->shift = NULL;
+          state->unshift = NULL;
+          state->next = NULL;
 
-	  if (!hash_insert (table, state))
-	    return NULL;
-	}
+          if (!hash_insert (table, state))
+            return NULL;
+        }
       return state;
     }
 }
 
 static struct state *
 find_shifted_state (struct state *state, unsigned character,
-		    RECODE_CONST_STEP step)
+                    RECODE_CONST_STEP step)
 {
   if (state)
     {
       struct state *shift = state->shift;
 
       while (shift)
-	if (shift->character == character)
-	  return shift;
-	else
-	  shift = shift->next;
+        if (shift->character == character)
+          return shift;
+        else
+          shift = shift->next;
 
       return NULL;
     }
@@ -376,9 +376,9 @@ find_shifted_state (struct state *state, unsigned character,
 
 bool
 init_combine (RECODE_STEP step,
-	      RECODE_CONST_REQUEST request _GL_UNUSED,
-	      RECODE_CONST_OPTION_LIST before_options,
-	      RECODE_CONST_OPTION_LIST after_options)
+              RECODE_CONST_REQUEST request _GL_UNUSED,
+              RECODE_CONST_OPTION_LIST before_options,
+              RECODE_CONST_OPTION_LIST after_options)
 {
   const unsigned short *data = (const unsigned short *) step->step_table;
   Hash_table *table;
@@ -403,31 +403,31 @@ init_combine (RECODE_STEP step,
       struct state *state = NULL;
 
       while (*data != DONE)
-	if (*data == ELSE)
-	  {
-	    if (state)
-	      {
-		if (state->result != NOT_A_CHARACTER)
-		  abort ();
-		state->result = result;
-		state = NULL;
-	      }
-	    data++;
-	  }
-	else
-	  {
-	    state = prepare_shifted_state (state, *data++, step);
-	    if (!state)
-	      return false;
-	  }
+        if (*data == ELSE)
+          {
+            if (state)
+              {
+                if (state->result != NOT_A_CHARACTER)
+                  abort ();
+                state->result = result;
+                state = NULL;
+              }
+            data++;
+          }
+        else
+          {
+            state = prepare_shifted_state (state, *data++, step);
+            if (!state)
+              return false;
+          }
 
       if (state)
-	{
-	  if (state->result != NOT_A_CHARACTER
-	      && state->result != state->character)
-	    abort ();
-	  state->result = result;
-	}
+        {
+          if (state->result != NOT_A_CHARACTER
+              && state->result != state->character)
+            abort ();
+          state->result = result;
+        }
       data++;
     }
 
@@ -484,39 +484,39 @@ combine_byte_byte (RECODE_SUBTASK subtask)
   if (value = get_byte (subtask), value != (unsigned)EOF)
     {
       while (true)
-	{
-	  struct state *shift
-	    = find_shifted_state (state, value, subtask->step);
+        {
+          struct state *shift
+            = find_shifted_state (state, value, subtask->step);
 
-	  if (shift)
-	    {
-	      state = shift;
-	      if (value = get_byte (subtask), value == (unsigned)EOF)
-		break;
-	    }
-	  else if (state)
-	    {
-	      if (state->result == NOT_A_CHARACTER)
-		backtrack_byte (state, subtask);
-	      else
-		put_byte (state->result, subtask);
-	      state = NULL;
-	    }
-	  else
-	    {
-	      put_byte (value, subtask);
-	      if (value = get_byte (subtask), value == (unsigned)EOF)
-		break;
-	    }
-	}
+          if (shift)
+            {
+              state = shift;
+              if (value = get_byte (subtask), value == (unsigned)EOF)
+                break;
+            }
+          else if (state)
+            {
+              if (state->result == NOT_A_CHARACTER)
+                backtrack_byte (state, subtask);
+              else
+                put_byte (state->result, subtask);
+              state = NULL;
+            }
+          else
+            {
+              put_byte (value, subtask);
+              if (value = get_byte (subtask), value == (unsigned)EOF)
+                break;
+            }
+        }
 
       if (state)
-	{
-	  if (state->result == NOT_A_CHARACTER)
-	    backtrack_byte (state, subtask);
-	  else
-	    put_byte (state->result, subtask);
-	}
+        {
+          if (state->result == NOT_A_CHARACTER)
+            backtrack_byte (state, subtask);
+          else
+            put_byte (state->result, subtask);
+        }
     }
 
   SUBTASK_RETURN (subtask);
@@ -531,39 +531,39 @@ combine_ucs2_byte (RECODE_SUBTASK subtask)
   if (get_ucs2 (&value, subtask))
     {
       while (true)
-	{
-	  struct state *shift
-	    = find_shifted_state (state, value, subtask->step);
+        {
+          struct state *shift
+            = find_shifted_state (state, value, subtask->step);
 
-	  if (shift)
-	    {
-	      state = shift;
-	      if (!get_ucs2 (&value, subtask))
-		break;
-	    }
-	  else if (state)
-	    {
-	      if (state->result == NOT_A_CHARACTER)
-		backtrack_byte (state, subtask);
-	      else
-		put_byte (state->result, subtask);
-	      state = NULL;
-	    }
-	  else
-	    {
-	      put_byte (value, subtask);
-	      if (!get_ucs2 (&value, subtask))
-		break;
-	    }
-	}
+          if (shift)
+            {
+              state = shift;
+              if (!get_ucs2 (&value, subtask))
+                break;
+            }
+          else if (state)
+            {
+              if (state->result == NOT_A_CHARACTER)
+                backtrack_byte (state, subtask);
+              else
+                put_byte (state->result, subtask);
+              state = NULL;
+            }
+          else
+            {
+              put_byte (value, subtask);
+              if (!get_ucs2 (&value, subtask))
+                break;
+            }
+        }
 
       if (state)
-	{
-	  if (state->result == NOT_A_CHARACTER)
-	    backtrack_byte (state, subtask);
-	  else
-	    put_byte (state->result, subtask);
-	}
+        {
+          if (state->result == NOT_A_CHARACTER)
+            backtrack_byte (state, subtask);
+          else
+            put_byte (state->result, subtask);
+        }
     }
 
   SUBTASK_RETURN (subtask);
@@ -579,42 +579,42 @@ combine_byte_ucs2 (RECODE_SUBTASK subtask)
       struct state *state = NULL;
 
       if (subtask->task->byte_order_mark)
-	put_ucs2 (BYTE_ORDER_MARK, subtask);
+        put_ucs2 (BYTE_ORDER_MARK, subtask);
 
       while (true)
-	{
-	  struct state *shift
-	    = find_shifted_state (state, value, subtask->step);
+        {
+          struct state *shift
+            = find_shifted_state (state, value, subtask->step);
 
-	  if (shift)
-	    {
-	      state = shift;
-	      if (value = get_byte (subtask), value == (unsigned)EOF)
-		break;
-	    }
-	  else if (state)
-	    {
-	      if (state->result == NOT_A_CHARACTER)
-		backtrack_ucs2 (state, subtask);
-	      else
-		put_ucs2 (state->result, subtask);
-	      state = NULL;
-	    }
-	  else
-	    {
-	      put_ucs2 (value, subtask);
-	      if (value = get_byte (subtask), value == (unsigned)EOF)
-		break;
-	    }
-	}
+          if (shift)
+            {
+              state = shift;
+              if (value = get_byte (subtask), value == (unsigned)EOF)
+                break;
+            }
+          else if (state)
+            {
+              if (state->result == NOT_A_CHARACTER)
+                backtrack_ucs2 (state, subtask);
+              else
+                put_ucs2 (state->result, subtask);
+              state = NULL;
+            }
+          else
+            {
+              put_ucs2 (value, subtask);
+              if (value = get_byte (subtask), value == (unsigned)EOF)
+                break;
+            }
+        }
 
       if (state)
-	{
-	  if (state->result == NOT_A_CHARACTER)
-	    backtrack_ucs2 (state, subtask);
-	  else
-	    put_ucs2 (state->result, subtask);
-	}
+        {
+          if (state->result == NOT_A_CHARACTER)
+            backtrack_ucs2 (state, subtask);
+          else
+            put_ucs2 (state->result, subtask);
+        }
     }
 
   SUBTASK_RETURN (subtask);
@@ -630,42 +630,42 @@ combine_ucs2_ucs2 (RECODE_SUBTASK subtask)
       struct state *state = NULL;
 
       if (subtask->task->byte_order_mark)
-	put_ucs2 (BYTE_ORDER_MARK, subtask);
+        put_ucs2 (BYTE_ORDER_MARK, subtask);
 
       while (true)
-	{
-	  struct state *shift
-	    = find_shifted_state (state, value, subtask->step);
+        {
+          struct state *shift
+            = find_shifted_state (state, value, subtask->step);
 
-	  if (shift)
-	    {
-	      state = shift;
-	      if (!get_ucs2 (&value, subtask))
-		break;
-	    }
-	  else if (state)
-	    {
-	      if (state->result == NOT_A_CHARACTER)
-		backtrack_ucs2 (state, subtask);
-	      else
-		put_ucs2 (state->result, subtask);
-	      state = NULL;
-	    }
-	  else
-	    {
-	      put_ucs2 (value, subtask);
-	      if (!get_ucs2 (&value, subtask))
-		break;
-	    }
-	}
+          if (shift)
+            {
+              state = shift;
+              if (!get_ucs2 (&value, subtask))
+                break;
+            }
+          else if (state)
+            {
+              if (state->result == NOT_A_CHARACTER)
+                backtrack_ucs2 (state, subtask);
+              else
+                put_ucs2 (state->result, subtask);
+              state = NULL;
+            }
+          else
+            {
+              put_ucs2 (value, subtask);
+              if (!get_ucs2 (&value, subtask))
+                break;
+            }
+        }
 
       if (state)
-	{
-	  if (state->result == NOT_A_CHARACTER)
-	    backtrack_ucs2 (state, subtask);
-	  else
-	    put_ucs2 (state->result, subtask);
-	}
+        {
+          if (state->result == NOT_A_CHARACTER)
+            backtrack_ucs2 (state, subtask);
+          else
+            put_ucs2 (state->result, subtask);
+        }
     }
 
   SUBTASK_RETURN (subtask);

--- a/src/dump.c
+++ b/src/dump.c
@@ -69,29 +69,29 @@ dump (RECODE_SUBTASK subtask,
       const char *cursor;
 
       for (byte_count = 1; byte_count < size; byte_count++)
-	{
-	  character = get_byte (subtask);
-	  if (character == EOF)
-	    break;
-	  value = (value << 8) | (BIT_MASK (8) & character);
-	}
+        {
+          character = get_byte (subtask);
+          if (character == EOF)
+            break;
+          value = (value << 8) | (BIT_MASK (8) & character);
+        }
 
       /* Write delimiters.  */
 
       if (column == per_line)
-	{
-	  put_byte (',', subtask);
-	  put_byte ('\n', subtask);
-	  column = 1;
-	}
+        {
+          put_byte (',', subtask);
+          put_byte ('\n', subtask);
+          column = 1;
+        }
       else if (column == 0)
-	column = 1;
+        column = 1;
       else
-	{
-	  put_byte (',', subtask);
-	  put_byte (' ', subtask);
-	  column++;
-	}
+        {
+          put_byte (',', subtask);
+          put_byte (' ', subtask);
+          column++;
+        }
 
       /* Write formatted value.  */
 
@@ -100,12 +100,12 @@ dump (RECODE_SUBTASK subtask,
       sprintf (buffer, format_table[base][byte_count], value);
 #pragma GCC diagnostic pop
       for (cursor = buffer; *cursor; cursor++)
-	put_byte (*cursor, subtask);
+        put_byte (*cursor, subtask);
 
       /* Prepare for next iteration.  */
 
       if (character != EOF)
-	character = get_byte (subtask);
+        character = get_byte (subtask);
     }
 
   put_byte ('\n', subtask);
@@ -114,7 +114,7 @@ dump (RECODE_SUBTASK subtask,
 
 static bool
 undump (RECODE_SUBTASK subtask,
-	enum base expected_base, unsigned expected_size)
+        enum base expected_base, unsigned expected_size)
 {
   unsigned per_line = per_line_table[expected_base][expected_size];
   unsigned column = 0;
@@ -132,188 +132,188 @@ undump (RECODE_SUBTASK subtask,
       /* Skip whitespace.  But count it, in case of a decimal number.  */
 
       while (character == ' ' || character == '\t' || character =='\n')
-	{
-	  if (character == ' ')
-	    width++;
-	  else
-	    RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
+        {
+          if (character == ' ')
+            width++;
+          else
+            RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
 
-	  character = get_byte (subtask);
-	}
+          character = get_byte (subtask);
+        }
       if (character == EOF)
-	{
-	  if (width != 0)
-	    RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
-	  break;
-	}
+        {
+          if (width != 0)
+            RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
+          break;
+        }
 
       /* Decide the base for the incoming character, possibly abort the
-	 recoding if not the proper base.  */
+         recoding if not the proper base.  */
 
       if (character == '0')
-	{
-	  character = get_byte (subtask);
+        {
+          character = get_byte (subtask);
 
-	  if (character == 'x')
-	    {
-	      if (width != 0)
-		RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
-	      width = 0;
-	      base = HEXADECIMAL;
-	      character = get_byte (subtask);
-	    }
-	  else if (character >= '0' && character <= '9')
-	    {
-	      /* If followed by 8 or 9, declare it octal nevertheless.  It
-		 is the proper thing to do, a reject might occur below.  */
-	      if (width != 0)
-		RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
-	      width = 0;
-	      base = OCTAL;
-	    }
-	  else
-	    {
-	      /* Otherwise, this is a simple, mere, happy decimal zero.  */
-	      width++;
-	      base = DECIMAL;
-	    }
-	}
+          if (character == 'x')
+            {
+              if (width != 0)
+                RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
+              width = 0;
+              base = HEXADECIMAL;
+              character = get_byte (subtask);
+            }
+          else if (character >= '0' && character <= '9')
+            {
+              /* If followed by 8 or 9, declare it octal nevertheless.  It
+                 is the proper thing to do, a reject might occur below.  */
+              if (width != 0)
+                RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
+              width = 0;
+              base = OCTAL;
+            }
+          else
+            {
+              /* Otherwise, this is a simple, mere, happy decimal zero.  */
+              width++;
+              base = DECIMAL;
+            }
+        }
       else if (character >= '1' && character <= '9')
-	base = DECIMAL;
+        base = DECIMAL;
       else
-	{
-	  /* This might be some other line of a C header.  Merely skip the
-	     line.  FIXME: This should probably skip multi-line comments or
-	     string constants, so to not get fooled by them.  */
+        {
+          /* This might be some other line of a C header.  Merely skip the
+             line.  FIXME: This should probably skip multi-line comments or
+             string constants, so to not get fooled by them.  */
 
-	  RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
-	  while (character != '\n' && character != EOF)
-	    character = get_byte (subtask);
-	  if (character == '\n')
-	    character = get_byte (subtask);
+          RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
+          while (character != '\n' && character != EOF)
+            character = get_byte (subtask);
+          if (character == '\n')
+            character = get_byte (subtask);
 
-	  continue;
-	}
+          continue;
+        }
 
       if (base != expected_base)
-	RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
+        RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
 
       /* Decode one value.  */
 
       switch (base)
-	{
-	case OCTAL:
-	  while (character >= '0' && character <= '7')
-	    {
-	      value = (value << 3) | (character - '0');
-	      width++;
-	      character = get_byte (subtask);
-	    }
-	  break;
+        {
+        case OCTAL:
+          while (character >= '0' && character <= '7')
+            {
+              value = (value << 3) | (character - '0');
+              width++;
+              character = get_byte (subtask);
+            }
+          break;
 
-	case DECIMAL:
-	  while (character >= '0' && character <= '9')
-	    {
-	      value = value * 10 + character - '0';
-	      width++;
-	      character = get_byte (subtask);
-	    }
-	  break;
+        case DECIMAL:
+          while (character >= '0' && character <= '9')
+            {
+              value = value * 10 + character - '0';
+              width++;
+              character = get_byte (subtask);
+            }
+          break;
 
-	case HEXADECIMAL:
-	  while (true)
-	    if (character >= '0' && character <= '9')
-	      {
-		value = (value << 4) | (character - '0');
-		width++;
-		character = get_byte (subtask);
-	      }
-	    else if (character >= 'A' && character <= 'F')
-	      {
-		value = (value << 4) | (character - 'A' + 10);
-		width++;
-		character = get_byte (subtask);
-	      }
-	    else if (character >= 'a' && character <= 'f')
-	      {
-		value = (value << 4) | (character - 'a' + 10);
-		width++;
-		character = get_byte (subtask);
-	      }
-	    else
-	      break;
-	  break;
+        case HEXADECIMAL:
+          while (true)
+            if (character >= '0' && character <= '9')
+              {
+                value = (value << 4) | (character - '0');
+                width++;
+                character = get_byte (subtask);
+              }
+            else if (character >= 'A' && character <= 'F')
+              {
+                value = (value << 4) | (character - 'A' + 10);
+                width++;
+                character = get_byte (subtask);
+              }
+            else if (character >= 'a' && character <= 'f')
+              {
+                value = (value << 4) | (character - 'a' + 10);
+                width++;
+                character = get_byte (subtask);
+              }
+            else
+              break;
+          break;
 
         default:
           break;
-	}
+        }
 
       if (width == 0 || width > width_table[base][expected_size])
-	{
-	  /* If the observed width is greater than expected, the input is
-	     invalid, even if the value is in range.  */
+        {
+          /* If the observed width is greater than expected, the input is
+             invalid, even if the value is in range.  */
 
-	  RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-	}
+          RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+        }
       else
-	{
-	  if (last_is_short)
-	    RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
-	  if (!comma_on_last)
-	    RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+        {
+          if (last_is_short)
+            RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
+          if (!comma_on_last)
+            RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
 
-	  /* Decide how many bytes to produce.  */
+          /* Decide how many bytes to produce.  */
 
-	  last_is_short = width < width_table[base][expected_size];
-	  if (last_is_short)
-	    {
-	      /* If the observed width is smaller than expected, accept the
-		 value as representing less than the expected number of
-		 bytes.  However, the width has to match very exactly.  */
+          last_is_short = width < width_table[base][expected_size];
+          if (last_is_short)
+            {
+              /* If the observed width is smaller than expected, accept the
+                 value as representing less than the expected number of
+                 bytes.  However, the width has to match very exactly.  */
 
-	      for (size = 1; size < 4; size++)
-		if (width_table[base][size] == width)
-		  break;
-	      if (size == 4)
-		{
-		  RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-		  continue;
-		}
-	    }
-	  else
-	    size = expected_size;
+              for (size = 1; size < 4; size++)
+                if (width_table[base][size] == width)
+                  break;
+              if (size == 4)
+                {
+                  RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+                  continue;
+                }
+            }
+          else
+            size = expected_size;
 
-	  /* Produce the output bytes.  */
+          /* Produce the output bytes.  */
           for (unsigned shift = size; shift != 0; shift--)
             put_byte (BIT_MASK (8) & value >> ((shift * 8) - 8), subtask);
-	}
+        }
 
       /* Skip separators.  */
 
       comma_on_last = character == ',';
       if (!comma_on_last)
-	{
-	  if (character == '\n')
-	    character = get_byte (subtask);
-	  else
-	    RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
-	}
+        {
+          if (character == '\n')
+            character = get_byte (subtask);
+          else
+            RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
+        }
       else
-	{
-	  character = get_byte (subtask);
-	  if (character == ' ')
-	    {
-	      column++;
-	      character = get_byte (subtask);
-	    }
-	  else if (character == '\n')
-	    {
-	      if (column + 1!= per_line)
-		RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
-	      column = 0;
-	      character = get_byte (subtask);
-	    }
-	}
+        {
+          character = get_byte (subtask);
+          if (character == ' ')
+            {
+              column++;
+              character = get_byte (subtask);
+            }
+          else if (character == '\n')
+            {
+              if (column + 1!= per_line)
+                RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
+              column = 0;
+              character = get_byte (subtask);
+            }
+        }
     }
 
   if (comma_on_last)
@@ -323,10 +323,10 @@ undump (RECODE_SUBTASK subtask,
 }
 
 #define TRANSFORM(Name, Service, Base, Size) \
-  static bool								\
-  Name (RECODE_SUBTASK subtask)	\
-  {									\
-    return Service (subtask, Base, Size);				\
+  static bool                                                           \
+  Name (RECODE_SUBTASK subtask) \
+  {                                                                     \
+    return Service (subtask, Base, Size);                               \
   }
 
 TRANSFORM (data_oct1, dump, OCTAL, 1)
@@ -385,23 +385,23 @@ module_dump (RECODE_OUTER outer)
   /* Double bytes.  */
 
     && declare_single (outer, "data", "Octal-2",
-		       outer->quality_variable_to_variable,
-		       NULL, data_oct2)
+                       outer->quality_variable_to_variable,
+                       NULL, data_oct2)
     && declare_single (outer, "data", "Decimal-2",
-		       outer->quality_variable_to_variable,
-		       NULL, data_dec2)
+                       outer->quality_variable_to_variable,
+                       NULL, data_dec2)
     && declare_single (outer, "data", "Hexadecimal-2",
-		       outer->quality_variable_to_variable,
-		       NULL, data_hex2)
+                       outer->quality_variable_to_variable,
+                       NULL, data_hex2)
     && declare_single (outer, "Octal-2", "data",
-		       outer->quality_variable_to_variable,
-		       NULL, oct2_data)
+                       outer->quality_variable_to_variable,
+                       NULL, oct2_data)
     && declare_single (outer, "Decimal-2", "data",
-		       outer->quality_variable_to_variable,
-		       NULL, dec2_data)
+                       outer->quality_variable_to_variable,
+                       NULL, dec2_data)
     && declare_single (outer, "Hexadecimal-2", "data",
-		       outer->quality_variable_to_variable,
-		       NULL, hex2_data)
+                       outer->quality_variable_to_variable,
+                       NULL, hex2_data)
 
     && declare_alias (outer, "o2", "Octal-2")
     && declare_alias (outer, "d2", "Decimal-2")
@@ -410,23 +410,23 @@ module_dump (RECODE_OUTER outer)
   /* Quadruple bytes.  */
 
     && declare_single (outer, "data", "Octal-4",
-		       outer->quality_variable_to_variable,
-		       NULL, data_oct4)
+                       outer->quality_variable_to_variable,
+                       NULL, data_oct4)
     && declare_single (outer, "data", "Decimal-4",
-		       outer->quality_variable_to_variable,
-		       NULL, data_dec4)
+                       outer->quality_variable_to_variable,
+                       NULL, data_dec4)
     && declare_single (outer, "data", "Hexadecimal-4",
-		       outer->quality_variable_to_variable,
-		       NULL, data_hex4)
+                       outer->quality_variable_to_variable,
+                       NULL, data_hex4)
     && declare_single (outer, "Octal-4", "data",
-		       outer->quality_variable_to_variable,
-		       NULL, oct4_data)
+                       outer->quality_variable_to_variable,
+                       NULL, oct4_data)
     && declare_single (outer, "Decimal-4", "data",
-		       outer->quality_variable_to_variable,
-		       NULL, dec4_data)
+                       outer->quality_variable_to_variable,
+                       NULL, dec4_data)
     && declare_single (outer, "Hexadecimal-4", "data",
-		       outer->quality_variable_to_variable,
-		       NULL, hex4_data)
+                       outer->quality_variable_to_variable,
+                       NULL, hex4_data)
 
     && declare_alias (outer, "o4", "Octal-4")
     && declare_alias (outer, "d4", "Decimal-4")

--- a/src/ebcdic.c
+++ b/src/ebcdic.c
@@ -139,9 +139,9 @@ static unsigned char const ascii_to_ebcdic_ibm[256] =
 
 static bool
 init_ascii_ebcdic (RECODE_STEP step,
-		   RECODE_CONST_REQUEST request _GL_UNUSED,
-		   RECODE_CONST_OPTION_LIST before_options,
-		   RECODE_CONST_OPTION_LIST after_options)
+                   RECODE_CONST_REQUEST request _GL_UNUSED,
+                   RECODE_CONST_OPTION_LIST before_options,
+                   RECODE_CONST_OPTION_LIST after_options)
 {
   if (before_options || after_options)
     return false;
@@ -154,9 +154,9 @@ init_ascii_ebcdic (RECODE_STEP step,
 
 static bool
 init_ebcdic_ascii (RECODE_STEP step,
-		   RECODE_CONST_REQUEST request,
-		   RECODE_CONST_OPTION_LIST before_options,
-		   RECODE_CONST_OPTION_LIST after_options)
+                   RECODE_CONST_REQUEST request,
+                   RECODE_CONST_OPTION_LIST before_options,
+                   RECODE_CONST_OPTION_LIST after_options)
 {
   if (before_options || after_options)
     return false;
@@ -174,9 +174,9 @@ init_ebcdic_ascii (RECODE_STEP step,
 
 static bool
 init_ascii_ebcdic_ccc (RECODE_STEP step,
-		       RECODE_CONST_REQUEST request _GL_UNUSED,
-		       RECODE_CONST_OPTION_LIST before_options,
-		       RECODE_CONST_OPTION_LIST after_options)
+                       RECODE_CONST_REQUEST request _GL_UNUSED,
+                       RECODE_CONST_OPTION_LIST before_options,
+                       RECODE_CONST_OPTION_LIST after_options)
 {
   if (before_options || after_options)
     return false;
@@ -189,9 +189,9 @@ init_ascii_ebcdic_ccc (RECODE_STEP step,
 
 static bool
 init_ebcdic_ccc_ascii (RECODE_STEP step,
-		       RECODE_CONST_REQUEST request,
-		       RECODE_CONST_OPTION_LIST before_options,
-		       RECODE_CONST_OPTION_LIST after_options)
+                       RECODE_CONST_REQUEST request,
+                       RECODE_CONST_OPTION_LIST before_options,
+                       RECODE_CONST_OPTION_LIST after_options)
 
 {
   if (before_options || after_options)
@@ -210,9 +210,9 @@ init_ebcdic_ccc_ascii (RECODE_STEP step,
 
 static bool
 init_ascii_ebcdic_ibm (RECODE_STEP step,
-		       RECODE_CONST_REQUEST request _GL_UNUSED,
-		       RECODE_CONST_OPTION_LIST before_options,
-		       RECODE_CONST_OPTION_LIST after_options)
+                       RECODE_CONST_REQUEST request _GL_UNUSED,
+                       RECODE_CONST_OPTION_LIST before_options,
+                       RECODE_CONST_OPTION_LIST after_options)
 {
   if (before_options || after_options)
     return false;
@@ -225,9 +225,9 @@ init_ascii_ebcdic_ibm (RECODE_STEP step,
 
 static bool
 init_ebcdic_ibm_ascii (RECODE_STEP step,
-		       RECODE_CONST_REQUEST request,
-		       RECODE_CONST_OPTION_LIST before_options,
-		       RECODE_CONST_OPTION_LIST after_options)
+                       RECODE_CONST_REQUEST request,
+                       RECODE_CONST_OPTION_LIST before_options,
+                       RECODE_CONST_OPTION_LIST after_options)
 {
   if (before_options || after_options)
     return false;
@@ -248,23 +248,23 @@ module_ebcdic (RECODE_OUTER outer)
 {
   return
     declare_single (outer, ASCII, "EBCDIC",
-		    outer->quality_byte_reversible,
-		    init_ascii_ebcdic, transform_byte_to_byte)
+                    outer->quality_byte_reversible,
+                    init_ascii_ebcdic, transform_byte_to_byte)
     && declare_single (outer, "EBCDIC", ASCII,
-		       outer->quality_byte_reversible,
-		       init_ebcdic_ascii, transform_byte_to_byte)
+                       outer->quality_byte_reversible,
+                       init_ebcdic_ascii, transform_byte_to_byte)
     && declare_single (outer, ASCII, "EBCDIC-CCC",
-		       outer->quality_byte_reversible,
-		       init_ascii_ebcdic_ccc, transform_byte_to_byte)
+                       outer->quality_byte_reversible,
+                       init_ascii_ebcdic_ccc, transform_byte_to_byte)
     && declare_single (outer, "EBCDIC-CCC", ASCII,
-		       outer->quality_byte_reversible,
-		       init_ebcdic_ccc_ascii, transform_byte_to_byte)
+                       outer->quality_byte_reversible,
+                       init_ebcdic_ccc_ascii, transform_byte_to_byte)
     && declare_single (outer, ASCII, "EBCDIC-IBM",
-		       outer->quality_byte_reversible,
-		       init_ascii_ebcdic_ibm, transform_byte_to_byte)
+                       outer->quality_byte_reversible,
+                       init_ascii_ebcdic_ibm, transform_byte_to_byte)
     && declare_single (outer, "EBCDIC-IBM", ASCII,
-		       outer->quality_byte_reversible,
-		       init_ebcdic_ibm_ascii, transform_byte_to_byte);
+                       outer->quality_byte_reversible,
+                       init_ebcdic_ibm_ascii, transform_byte_to_byte);
 }
 
 void

--- a/src/endline.c
+++ b/src/endline.c
@@ -21,9 +21,9 @@
 #include "common.h"
 #include "decsteps.h"
 
-#define CR 13			/* carriage return */
-#define LF 10			/* line feed */
-#define OLD_EOF 26		/* oldish end of file */
+#define CR 13                   /* carriage return */
+#define LF 10                   /* line feed */
+#define OLD_EOF 26              /* oldish end of file */
 
 static bool
 transform_data_cr (RECODE_SUBTASK subtask)
@@ -35,20 +35,20 @@ transform_data_cr (RECODE_SUBTASK subtask)
     switch (character)
       {
       case '\n':
-	put_byte (CR, subtask);
-	break;
+        put_byte (CR, subtask);
+        break;
 
       case CR:
-	if (!strict)
-	  {
-	    put_byte ('\n', subtask);
-	    break;
-	  }
-	RETURN_IF_NOGO (RECODE_AMBIGUOUS_OUTPUT, subtask);
-	FALLTHROUGH;
+        if (!strict)
+          {
+            put_byte ('\n', subtask);
+            break;
+          }
+        RETURN_IF_NOGO (RECODE_AMBIGUOUS_OUTPUT, subtask);
+        FALLTHROUGH;
 
       default:
-	put_byte (character, subtask);
+        put_byte (character, subtask);
       }
 
   SUBTASK_RETURN (subtask);
@@ -64,20 +64,20 @@ transform_cr_data (RECODE_SUBTASK subtask)
     switch (character)
       {
       case CR:
-	put_byte ('\n', subtask);
-	break;
+        put_byte ('\n', subtask);
+        break;
 
       case '\n':
-	if (!strict)
-	  {
-	    put_byte (CR, subtask);
-	    break;
-	  }
-	RETURN_IF_NOGO (RECODE_AMBIGUOUS_OUTPUT, subtask);
-	FALLTHROUGH;
+        if (!strict)
+          {
+            put_byte (CR, subtask);
+            break;
+          }
+        RETURN_IF_NOGO (RECODE_AMBIGUOUS_OUTPUT, subtask);
+        FALLTHROUGH;
 
       default:
-	put_byte (character, subtask);
+        put_byte (character, subtask);
       }
 
   SUBTASK_RETURN (subtask);
@@ -92,25 +92,25 @@ transform_data_crlf (RECODE_SUBTASK subtask)
     switch (character)
       {
       case '\n':
-	put_byte (CR, subtask);
-	put_byte (LF, subtask);
-	character = get_byte (subtask);
-	break;
+        put_byte (CR, subtask);
+        put_byte (LF, subtask);
+        character = get_byte (subtask);
+        break;
 
       case CR:
-	character = get_byte (subtask);
-	if (character == LF)
-	  RETURN_IF_NOGO (RECODE_AMBIGUOUS_OUTPUT, subtask);
-	put_byte (CR, subtask);
-	break;
+        character = get_byte (subtask);
+        if (character == LF)
+          RETURN_IF_NOGO (RECODE_AMBIGUOUS_OUTPUT, subtask);
+        put_byte (CR, subtask);
+        break;
 
       case OLD_EOF:
-	RETURN_IF_NOGO (RECODE_AMBIGUOUS_OUTPUT, subtask);
-	FALLTHROUGH;
+        RETURN_IF_NOGO (RECODE_AMBIGUOUS_OUTPUT, subtask);
+        FALLTHROUGH;
 
       default:
-	put_byte (character, subtask);
-	character = get_byte (subtask);
+        put_byte (character, subtask);
+        character = get_byte (subtask);
       }
 
   SUBTASK_RETURN (subtask);
@@ -125,27 +125,27 @@ transform_crlf_data (RECODE_SUBTASK subtask)
     switch (character)
       {
       case OLD_EOF:
-	RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
-	SUBTASK_RETURN (subtask);
+        RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
+        SUBTASK_RETURN (subtask);
 
       case CR:
-	character = get_byte (subtask);
-	if (character == LF)
-	  {
-	    put_byte ('\n', subtask);
-	    character = get_byte (subtask);
-	  }
-	else
-	  put_byte (CR, subtask);
-	break;
+        character = get_byte (subtask);
+        if (character == LF)
+          {
+            put_byte ('\n', subtask);
+            character = get_byte (subtask);
+          }
+        else
+          put_byte (CR, subtask);
+        break;
 
       case LF:
-	RETURN_IF_NOGO (RECODE_AMBIGUOUS_OUTPUT, subtask);
-	FALLTHROUGH;
+        RETURN_IF_NOGO (RECODE_AMBIGUOUS_OUTPUT, subtask);
+        FALLTHROUGH;
 
       default:
-	put_byte (character, subtask);
-	character = get_byte (subtask);
+        put_byte (character, subtask);
+        character = get_byte (subtask);
       }
 
   SUBTASK_RETURN (subtask);
@@ -156,17 +156,17 @@ module_endline (RECODE_OUTER outer)
 {
   return
     declare_single (outer, "data", "CR",
-		    outer->quality_byte_to_byte,
-		    NULL, transform_data_cr)
+                    outer->quality_byte_to_byte,
+                    NULL, transform_data_cr)
     && declare_single (outer, "CR", "data",
-		       outer->quality_byte_to_byte,
-		       NULL, transform_cr_data)
+                       outer->quality_byte_to_byte,
+                       NULL, transform_cr_data)
     && declare_single (outer, "data", "CR-LF",
-		       outer->quality_byte_to_variable,
-		       NULL, transform_data_crlf)
+                       outer->quality_byte_to_variable,
+                       NULL, transform_data_crlf)
     && declare_single (outer, "CR-LF", "data",
-		       outer->quality_variable_to_byte,
-		       NULL, transform_crlf_data)
+                       outer->quality_variable_to_byte,
+                       NULL, transform_crlf_data)
 
     && declare_alias (outer, "cl", "CR-LF");
 }

--- a/src/flat.c
+++ b/src/flat.c
@@ -24,41 +24,41 @@
 static bool
 transform_ascii_flat (RECODE_SUBTASK subtask)
 {
-  int input_char;		/* current character */
-  int temp_char;		/* look ahead character */
+  int input_char;               /* current character */
+  int temp_char;                /* look ahead character */
 
   input_char = get_byte (subtask);
   while (true)
     switch (input_char)
       {
       case EOF:
-	SUBTASK_RETURN (subtask);
+        SUBTASK_RETURN (subtask);
 
       case '\n':
       case '\t':
-	put_byte (input_char, subtask);
-	input_char = get_byte (subtask);
-	break;
+        put_byte (input_char, subtask);
+        input_char = get_byte (subtask);
+        break;
 
       case '\b':
-	input_char = get_byte (subtask);
-	switch (input_char)
-	  {
-	  case '\'':
-	  case '`':
-	  case '^':
-	  case '"':
-	  case '~':
-	  case ',':
-	  case '_':
-	    RETURN_IF_NOGO (RECODE_AMBIGUOUS_OUTPUT, subtask);
-	    input_char = get_byte (subtask);
-	    break;
+        input_char = get_byte (subtask);
+        switch (input_char)
+          {
+          case '\'':
+          case '`':
+          case '^':
+          case '"':
+          case '~':
+          case ',':
+          case '_':
+            RETURN_IF_NOGO (RECODE_AMBIGUOUS_OUTPUT, subtask);
+            input_char = get_byte (subtask);
+            break;
 
-	  default:
-	    put_byte ('\b', subtask);
-	  }
-	break;
+          default:
+            put_byte ('\b', subtask);
+          }
+        break;
 
       case '\'':
       case '`':
@@ -67,35 +67,35 @@ transform_ascii_flat (RECODE_SUBTASK subtask)
       case '~':
       case ',':
       case '_':
-	temp_char = get_byte (subtask);
-	if (temp_char == '\b')
-	  {
-	    RETURN_IF_NOGO (RECODE_AMBIGUOUS_OUTPUT, subtask);
-	    input_char = get_byte (subtask);
-	  }
-	else
-	  {
-	    put_byte (input_char, subtask);
-	    input_char = temp_char;
-	  }
-	break;
+        temp_char = get_byte (subtask);
+        if (temp_char == '\b')
+          {
+            RETURN_IF_NOGO (RECODE_AMBIGUOUS_OUTPUT, subtask);
+            input_char = get_byte (subtask);
+          }
+        else
+          {
+            put_byte (input_char, subtask);
+            input_char = temp_char;
+          }
+        break;
 
       default:
-	if (!IS_ASCII (input_char))
-	  {
-	    RETURN_IF_NOGO (RECODE_AMBIGUOUS_OUTPUT, subtask);
-	    put_byte ('M', subtask);
-	    put_byte ('-', subtask);
-	    input_char &= BIT_MASK (7);
-	  }
-	if (input_char < ' ' || input_char == BIT_MASK (7))
-	  {
-	    RETURN_IF_NOGO (RECODE_AMBIGUOUS_OUTPUT, subtask);
-	    put_byte ('^', subtask);
-	    input_char ^= (1 << 6);
-	  }
-	put_byte (input_char, subtask);
-	input_char = get_byte (subtask);
+        if (!IS_ASCII (input_char))
+          {
+            RETURN_IF_NOGO (RECODE_AMBIGUOUS_OUTPUT, subtask);
+            put_byte ('M', subtask);
+            put_byte ('-', subtask);
+            input_char &= BIT_MASK (7);
+          }
+        if (input_char < ' ' || input_char == BIT_MASK (7))
+          {
+            RETURN_IF_NOGO (RECODE_AMBIGUOUS_OUTPUT, subtask);
+            put_byte ('^', subtask);
+            input_char ^= (1 << 6);
+          }
+        put_byte (input_char, subtask);
+        input_char = get_byte (subtask);
       }
 }
 
@@ -103,8 +103,8 @@ bool
 module_flat (RECODE_OUTER outer)
 {
   if (!declare_single (outer, "ASCII-BS", "flat",
-		       outer->quality_variable_to_variable,
-		       NULL, transform_ascii_flat))
+                       outer->quality_variable_to_variable,
+                       NULL, transform_ascii_flat))
     return false;
 
   return true;

--- a/src/fr-charname.c
+++ b/src/fr-charname.c
@@ -23,7 +23,7 @@
 
 /*--------------------------------------------------------------------.
 | Return a statically allocated full charname associated with a given |
-| SYMBOL, or NULL if not found.					      |
+| SYMBOL, or NULL if not found.                                       |
 `--------------------------------------------------------------------*/
 
 const char *
@@ -46,11 +46,11 @@ ucs2_to_french_charname (int ucs2)
     {
       middle = (first + last) / 2;
       if (charname[middle].code < ucs2)
-	first = middle + 1;
+        first = middle + 1;
       else if (charname[middle].code > ucs2)
-	last = middle;
+        last = middle;
       else
-	break;
+        break;
     }
 
   /* If the UCS value has not been found, return the NULL string.  */
@@ -68,18 +68,18 @@ ucs2_to_french_charname (int ucs2)
 
       value = *(const unsigned char *) in - 1;
       if (value >= NUMBER_OF_SINGLES)
-	value = (NUMBER_OF_SINGLES + 255 * (value - NUMBER_OF_SINGLES)
-		 + *(const unsigned char *) ++in - 1);
+        value = (NUMBER_OF_SINGLES + 255 * (value - NUMBER_OF_SINGLES)
+                 + *(const unsigned char *) ++in - 1);
 
       /* Copy it.  */
 
       if (out)
-	*out++ = ' ';
+        *out++ = ' ';
       else
-	out = result;
+        out = result;
 
       for (cursor = word[value]; *cursor; cursor++)
-	*out++ = *cursor;
+        *out++ = *cursor;
     }
 
   /* Return the result.  */

--- a/src/html.c
+++ b/src/html.c
@@ -31,354 +31,354 @@
 /* The following entities, said to be from Emacs-w3, are ignored for the
    time being, as recode is not too fond of graphical approximations:
 
-	&ensp;          \
-	&emsp;          \ \
-	&ndash;         -
-	&mdash;         --
-	&lsquo;         `
-	&rsquo;         '
-	&ldquo;         ``
-	&rdquo;         ''
-	&frac18;        1/8
-	&frac38;        3/8
-	&frac58;        5/8
-	&frac78;        7/8
-	&hellip;        . . .
-	&larr;          <--
-	&rarr;          -->
-	&trade;         (TM)
+        &ensp;          \
+        &emsp;          \ \
+        &ndash;         -
+        &mdash;         --
+        &lsquo;         `
+        &rsquo;         '
+        &ldquo;         ``
+        &rdquo;         ''
+        &frac18;        1/8
+        &frac38;        3/8
+        &frac58;        5/8
+        &frac78;        7/8
+        &hellip;        . . .
+        &larr;          <--
+        &rarr;          -->
+        &trade;         (TM)
 */
 
 /* XML with stand-alone=yes */
-#define V00		(1 << 0)
+#define V00             (1 << 0)
 /* Old Emacs-W3, HTML 1.1 ? */
-#define V11		(1 << 1)
+#define V11             (1 << 1)
 /* RFC1866, HTML 2.0 */
-#define V20		(1 << 2)
+#define V20             (1 << 2)
 /* RFC2070, HTML-i18n */
-#define V27		(1 << 3)
+#define V27             (1 << 3)
 /* HTML 3.2 */
-#define V32		(1 << 4)
+#define V32             (1 << 4)
 /* HTML 4.0 */
-#define V40		(1 << 5)
+#define V40             (1 << 5)
 
 #define ENTRY(Code, String, Flags) \
   { Code, Flags, String }
 
 static struct ucs2_to_string translations [] =
   {
-    ENTRY (33, "excl",      0       				 ),
-    ENTRY (34, "quot",      0 | V00 	  | V20 | V27 | V32 | V40),
-    ENTRY (35, "num",       0       				 ),
-    ENTRY (36, "dollar",    0       				 ),
-    ENTRY (37, "percnt",    0       				 ),
+    ENTRY (33, "excl",      0                                    ),
+    ENTRY (34, "quot",      0 | V00       | V20 | V27 | V32 | V40),
+    ENTRY (35, "num",       0                                    ),
+    ENTRY (36, "dollar",    0                                    ),
+    ENTRY (37, "percnt",    0                                    ),
     ENTRY (38, "amp",       0 | V00 | V11 | V20 | V27 | V32 | V40),
-    ENTRY (39, "apos",      0 | V00 				 ),
-    ENTRY (40, "lpar",      0       				 ),
-    ENTRY (41, "rpar",      0       				 ),
-    ENTRY (42, "ast",       0       				 ),
-    ENTRY (43, "plus",      0       				 ),
-    ENTRY (44, "comma",     0       				 ),
-    ENTRY (45, "horbar",    0       				 ),
-    ENTRY (46, "period",    0       				 ),
-    ENTRY (58, "colon",     0       				 ),
-    ENTRY (59, "semi",      0       				 ),
+    ENTRY (39, "apos",      0 | V00                              ),
+    ENTRY (40, "lpar",      0                                    ),
+    ENTRY (41, "rpar",      0                                    ),
+    ENTRY (42, "ast",       0                                    ),
+    ENTRY (43, "plus",      0                                    ),
+    ENTRY (44, "comma",     0                                    ),
+    ENTRY (45, "horbar",    0                                    ),
+    ENTRY (46, "period",    0                                    ),
+    ENTRY (58, "colon",     0                                    ),
+    ENTRY (59, "semi",      0                                    ),
     ENTRY (60, "lt",        0 | V00 | V11 | V20 | V27 | V32 | V40),
-    ENTRY (61, "equals",    0       				 ),
+    ENTRY (61, "equals",    0                                    ),
     ENTRY (62, "gt",        0 | V00 | V11 | V20 | V27 | V32 | V40),
-    ENTRY (63, "quest",     0       				 ),
-    ENTRY (64, "commat",    0       				 ),
-    ENTRY (91, "lsqb",      0       				 ),
-    ENTRY (93, "rsqb",      0       				 ),
-    ENTRY (94, "uarr",      0       				 ),
-    ENTRY (95, "lowbar",    0       				 ),
-    ENTRY (96, "grave",     0       				 ),
-    ENTRY (123, "lcub",     0       				 ),
-    ENTRY (124, "verbar",   0       				 ),
-    ENTRY (125, "rcub",     0       				 ),
-    ENTRY (126, "tilde",    0       				 ),
-    ENTRY (160, "nbsp",     0       		| V27 | V32 | V40),
-    ENTRY (161, "iexcl",    0       		| V27 | V32 | V40),
-    ENTRY (162, "cent",     0       		| V27 | V32 | V40),
-    ENTRY (163, "pound",    0       		| V27 | V32 | V40),
-    ENTRY (164, "curren",   0       		| V27 | V32 | V40),
-    ENTRY (165, "yen",      0       		| V27 | V32 | V40),
+    ENTRY (63, "quest",     0                                    ),
+    ENTRY (64, "commat",    0                                    ),
+    ENTRY (91, "lsqb",      0                                    ),
+    ENTRY (93, "rsqb",      0                                    ),
+    ENTRY (94, "uarr",      0                                    ),
+    ENTRY (95, "lowbar",    0                                    ),
+    ENTRY (96, "grave",     0                                    ),
+    ENTRY (123, "lcub",     0                                    ),
+    ENTRY (124, "verbar",   0                                    ),
+    ENTRY (125, "rcub",     0                                    ),
+    ENTRY (126, "tilde",    0                                    ),
+    ENTRY (160, "nbsp",     0                   | V27 | V32 | V40),
+    ENTRY (161, "iexcl",    0                   | V27 | V32 | V40),
+    ENTRY (162, "cent",     0                   | V27 | V32 | V40),
+    ENTRY (163, "pound",    0                   | V27 | V32 | V40),
+    ENTRY (164, "curren",   0                   | V27 | V32 | V40),
+    ENTRY (165, "yen",      0                   | V27 | V32 | V40),
     ENTRY (166, "brkbar",   0       | V11                        ),
-    ENTRY (166, "brvbar",   0       		| V27 | V32 | V40),
-    ENTRY (167, "sect",     0       		| V27 | V32 | V40),
+    ENTRY (166, "brvbar",   0                   | V27 | V32 | V40),
+    ENTRY (167, "sect",     0                   | V27 | V32 | V40),
     ENTRY (168, "die",      0       | V11                        ),
-    ENTRY (168, "uml",      0       		| V27 | V32 | V40),
-    ENTRY (169, "copy",     0       		| V27 | V32 | V40),
-    ENTRY (170, "ordf",     0       		| V27 | V32 | V40),
-    ENTRY (171, "laquo",    0       		| V27 | V32 | V40),
-    ENTRY (172, "not",      0       		| V27 | V32 | V40),
+    ENTRY (168, "uml",      0                   | V27 | V32 | V40),
+    ENTRY (169, "copy",     0                   | V27 | V32 | V40),
+    ENTRY (170, "ordf",     0                   | V27 | V32 | V40),
+    ENTRY (171, "laquo",    0                   | V27 | V32 | V40),
+    ENTRY (172, "not",      0                   | V27 | V32 | V40),
     ENTRY (173, "hyphen",   0       | V11                        ),
-    ENTRY (173, "shy",      0       		| V27 | V32 | V40),
-    ENTRY (174, "reg",      0       		| V27 | V32 | V40),
+    ENTRY (173, "shy",      0                   | V27 | V32 | V40),
+    ENTRY (174, "reg",      0                   | V27 | V32 | V40),
     ENTRY (175, "hibar",    0       | V11                        ),
-    ENTRY (175, "macr",     0       		| V27 | V32 | V40),
-    ENTRY (176, "deg",      0       		| V27 | V32 | V40),
-    ENTRY (177, "plusmn",   0       		| V27 | V32 | V40),
-    ENTRY (178, "sup2",     0       		| V27 | V32 | V40),
-    ENTRY (179, "sup3",     0       		| V27 | V32 | V40),
-    ENTRY (180, "acute",    0       		| V27 | V32 | V40),
-    ENTRY (181, "micro",    0       		| V27 | V32 | V40),
-    ENTRY (182, "para",     0       		| V27 | V32 | V40),
-    ENTRY (183, "middot",   0       		| V27 | V32 | V40),
-    ENTRY (184, "cedil",    0       		| V27 | V32 | V40),
-    ENTRY (185, "sup1",     0       		| V27 | V32 | V40),
-    ENTRY (186, "ordm",     0       		| V27 | V32 | V40),
-    ENTRY (187, "raquo",    0       		| V27 | V32 | V40),
-    ENTRY (188, "frac14",   0       		| V27 | V32 | V40),
+    ENTRY (175, "macr",     0                   | V27 | V32 | V40),
+    ENTRY (176, "deg",      0                   | V27 | V32 | V40),
+    ENTRY (177, "plusmn",   0                   | V27 | V32 | V40),
+    ENTRY (178, "sup2",     0                   | V27 | V32 | V40),
+    ENTRY (179, "sup3",     0                   | V27 | V32 | V40),
+    ENTRY (180, "acute",    0                   | V27 | V32 | V40),
+    ENTRY (181, "micro",    0                   | V27 | V32 | V40),
+    ENTRY (182, "para",     0                   | V27 | V32 | V40),
+    ENTRY (183, "middot",   0                   | V27 | V32 | V40),
+    ENTRY (184, "cedil",    0                   | V27 | V32 | V40),
+    ENTRY (185, "sup1",     0                   | V27 | V32 | V40),
+    ENTRY (186, "ordm",     0                   | V27 | V32 | V40),
+    ENTRY (187, "raquo",    0                   | V27 | V32 | V40),
+    ENTRY (188, "frac14",   0                   | V27 | V32 | V40),
     ENTRY (189, "half",     0       | V11                        ),
-    ENTRY (189, "frac12",   0       		| V27 | V32 | V40),
-    ENTRY (190, "frac34",   0       		| V27 | V32 | V40),
-    ENTRY (191, "iquest",   0       		| V27 | V32 | V40),
+    ENTRY (189, "frac12",   0                   | V27 | V32 | V40),
+    ENTRY (190, "frac34",   0                   | V27 | V32 | V40),
+    ENTRY (191, "iquest",   0                   | V27 | V32 | V40),
     ENTRY (192, "Agrave",   0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (193, "Aacute",   0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (194, "Acircu",   0       | V11                        ),
-    ENTRY (194, "Acirc",    0       	  | V20 | V27 | V32 | V40),
+    ENTRY (194, "Acirc",    0             | V20 | V27 | V32 | V40),
     ENTRY (195, "Atilde",   0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (196, "Adiaer",   0       | V11                        ),
-    ENTRY (196, "Auml",     0       	  | V20 | V27 | V32 | V40),
+    ENTRY (196, "Auml",     0             | V20 | V27 | V32 | V40),
     ENTRY (197, "Aring",    0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (198, "AE",       0       | V11                        ),
-    ENTRY (198, "AElig",    0       	  | V20 | V27 | V32 | V40),
+    ENTRY (198, "AElig",    0             | V20 | V27 | V32 | V40),
     ENTRY (199, "Ccedil",   0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (200, "Egrave",   0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (201, "Eacute",   0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (202, "Ecircu",   0       | V11                        ),
-    ENTRY (202, "Ecirc",    0       	  | V20 | V27 | V32 | V40),
+    ENTRY (202, "Ecirc",    0             | V20 | V27 | V32 | V40),
     ENTRY (203, "Ediaer",   0       | V11                        ),
-    ENTRY (203, "Euml",     0       	  | V20 | V27 | V32 | V40),
+    ENTRY (203, "Euml",     0             | V20 | V27 | V32 | V40),
     ENTRY (204, "Igrave",   0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (205, "Iacute",   0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (206, "Icircu",   0       | V11                        ),
-    ENTRY (206, "Icirc",    0       	  | V20 | V27 | V32 | V40),
+    ENTRY (206, "Icirc",    0             | V20 | V27 | V32 | V40),
     ENTRY (207, "Idiaer",   0       | V11                        ),
-    ENTRY (207, "Iuml",     0       	  | V20 | V27 | V32 | V40),
+    ENTRY (207, "Iuml",     0             | V20 | V27 | V32 | V40),
     ENTRY (208, "ETH",      0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (209, "Ntilde",   0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (210, "Ograve",   0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (211, "Oacute",   0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (212, "Ocircu",   0       | V11                        ),
-    ENTRY (212, "Ocirc",    0       	  | V20 | V27 | V32 | V40),
+    ENTRY (212, "Ocirc",    0             | V20 | V27 | V32 | V40),
     ENTRY (213, "Otilde",   0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (214, "Odiaer",   0       | V11                        ),
-    ENTRY (214, "Ouml",     0       	  | V20 | V27 | V32 | V40),
+    ENTRY (214, "Ouml",     0             | V20 | V27 | V32 | V40),
     ENTRY (215, "MULT",     0       | V11                        ),
-    ENTRY (215, "times",    0       		| V27 | V32 | V40),
+    ENTRY (215, "times",    0                   | V27 | V32 | V40),
     ENTRY (216, "Ostroke",  0       | V11                        ),
-    ENTRY (216, "Oslash",   0       	  | V20 | V27 | V32 | V40),
+    ENTRY (216, "Oslash",   0             | V20 | V27 | V32 | V40),
     ENTRY (217, "Ugrave",   0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (218, "Uacute",   0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (219, "Ucircu",   0       | V11                        ),
-    ENTRY (219, "Ucirc",    0       	  | V20 | V27 | V32 | V40),
+    ENTRY (219, "Ucirc",    0             | V20 | V27 | V32 | V40),
     ENTRY (220, "Udiaer",   0       | V11                        ),
-    ENTRY (220, "Uuml",     0       	  | V20 | V27 | V32 | V40),
+    ENTRY (220, "Uuml",     0             | V20 | V27 | V32 | V40),
     ENTRY (221, "Yacute",   0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (222, "THORN",    0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (223, "ssharp",   0       | V11                        ),
-    ENTRY (223, "szlig",    0       	  | V20 | V27 | V32 | V40),
+    ENTRY (223, "szlig",    0             | V20 | V27 | V32 | V40),
     ENTRY (224, "agrave",   0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (225, "aacute",   0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (226, "acircu",   0       | V11                        ),
-    ENTRY (226, "acirc",    0       	  | V20 | V27 | V32 | V40),
+    ENTRY (226, "acirc",    0             | V20 | V27 | V32 | V40),
     ENTRY (227, "atilde",   0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (228, "adiaer",   0       | V11                        ),
-    ENTRY (228, "auml",     0       	  | V20 | V27 | V32 | V40),
+    ENTRY (228, "auml",     0             | V20 | V27 | V32 | V40),
     ENTRY (229, "aring",    0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (230, "ae",       0       | V11                        ),
-    ENTRY (230, "aelig",    0       	  | V20 | V27 | V32 | V40),
+    ENTRY (230, "aelig",    0             | V20 | V27 | V32 | V40),
     ENTRY (231, "ccedil",   0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (232, "egrave",   0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (233, "eacute",   0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (234, "ecircu",   0       | V11                        ),
-    ENTRY (234, "ecirc",    0       	  | V20 | V27 | V32 | V40),
+    ENTRY (234, "ecirc",    0             | V20 | V27 | V32 | V40),
     ENTRY (235, "ediaer",   0       | V11                        ),
-    ENTRY (235, "euml",     0       	  | V20 | V27 | V32 | V40),
+    ENTRY (235, "euml",     0             | V20 | V27 | V32 | V40),
     ENTRY (236, "igrave",   0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (237, "iacute",   0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (238, "icircu",   0       | V11                        ),
-    ENTRY (238, "icirc",    0       	  | V20 | V27 | V32 | V40),
+    ENTRY (238, "icirc",    0             | V20 | V27 | V32 | V40),
     ENTRY (239, "idiaer",   0       | V11                        ),
-    ENTRY (239, "iuml",     0       	  | V20 | V27 | V32 | V40),
+    ENTRY (239, "iuml",     0             | V20 | V27 | V32 | V40),
     ENTRY (240, "eth",      0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (241, "ntilde",   0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (242, "ograve",   0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (243, "oacute",   0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (244, "ocircu",   0       | V11                        ),
-    ENTRY (244, "ocirc",    0       	  | V20 | V27 | V32 | V40),
+    ENTRY (244, "ocirc",    0             | V20 | V27 | V32 | V40),
     ENTRY (245, "otilde",   0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (246, "odiaer",   0       | V11                        ),
-    ENTRY (246, "ouml",     0       	  | V20 | V27 | V32 | V40),
+    ENTRY (246, "ouml",     0             | V20 | V27 | V32 | V40),
     ENTRY (247, "DIVIS",    0       | V11                        ),
-    ENTRY (247, "divide",   0       		| V27 | V32 | V40),
+    ENTRY (247, "divide",   0                   | V27 | V32 | V40),
     ENTRY (248, "ostroke",  0       | V11                        ),
-    ENTRY (248, "oslash",   0       	  | V20 | V27 | V32 | V40),
+    ENTRY (248, "oslash",   0             | V20 | V27 | V32 | V40),
     ENTRY (249, "ugrave",   0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (250, "uacute",   0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (251, "ucircu",   0       | V11                        ),
-    ENTRY (251, "ucirc",    0       	  | V20 | V27 | V32 | V40),
+    ENTRY (251, "ucirc",    0             | V20 | V27 | V32 | V40),
     ENTRY (252, "udiaer",   0       | V11                        ),
-    ENTRY (252, "uuml",     0       	  | V20 | V27 | V32 | V40),
+    ENTRY (252, "uuml",     0             | V20 | V27 | V32 | V40),
     ENTRY (253, "yacute",   0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (254, "thorn",    0       | V11 | V20 | V27 | V32 | V40),
     ENTRY (255, "ydiaer",   0       | V11                        ),
-    ENTRY (255, "yuml",     0       	  | V20 | V27 | V32 | V40),
-    ENTRY (338, "OElig",    0       			    | V40),
-    ENTRY (339, "oelig",    0       			    | V40),
-    ENTRY (352, "Scaron",   0       			    | V40),
-    ENTRY (353, "scaron",   0       			    | V40),
-    ENTRY (376, "Yuml",     0       			    | V40),
-    ENTRY (402, "fnof",     0       			    | V40),
-    ENTRY (710, "circ",     0       			    | V40),
-    ENTRY (732, "tilde",    0       			    | V40),
-    ENTRY (913, "Alpha",    0       			    | V40),
-    ENTRY (914, "Beta",     0       			    | V40),
-    ENTRY (915, "Gamma",    0       			    | V40),
-    ENTRY (916, "Delta",    0       			    | V40),
-    ENTRY (917, "Epsilon",  0       			    | V40),
-    ENTRY (918, "Zeta",     0       			    | V40),
-    ENTRY (919, "Eta",      0       			    | V40),
-    ENTRY (920, "Theta",    0       			    | V40),
-    ENTRY (921, "Iota",     0       			    | V40),
-    ENTRY (922, "Kappa",    0       			    | V40),
-    ENTRY (923, "Lambda",   0       			    | V40),
-    ENTRY (924, "Mu",       0       			    | V40),
-    ENTRY (925, "Nu",       0       			    | V40),
-    ENTRY (926, "Xi",       0       			    | V40),
-    ENTRY (927, "Omicron",  0       			    | V40),
-    ENTRY (928, "Pi",       0       			    | V40),
-    ENTRY (929, "Rho",      0       			    | V40),
-    ENTRY (931, "Sigma",    0       			    | V40),
-    ENTRY (932, "Tau",      0       			    | V40),
-    ENTRY (933, "Upsilon",  0       			    | V40),
-    ENTRY (934, "Phi",      0       			    | V40),
-    ENTRY (935, "Chi",      0       			    | V40),
-    ENTRY (936, "Psi",      0       			    | V40),
-    ENTRY (937, "Omega",    0       			    | V40),
-    ENTRY (945, "alpha",    0       			    | V40),
-    ENTRY (946, "beta",     0       			    | V40),
-    ENTRY (947, "gamma",    0       			    | V40),
-    ENTRY (948, "delta",    0       			    | V40),
-    ENTRY (949, "epsilon",  0       			    | V40),
-    ENTRY (950, "zeta",     0       			    | V40),
-    ENTRY (951, "eta",      0       			    | V40),
-    ENTRY (952, "theta",    0       			    | V40),
-    ENTRY (953, "iota",     0       			    | V40),
-    ENTRY (954, "kappa",    0       			    | V40),
-    ENTRY (955, "lambda",   0       			    | V40),
-    ENTRY (956, "mu",       0       			    | V40),
-    ENTRY (957, "nu",       0       			    | V40),
-    ENTRY (958, "xi",       0       			    | V40),
-    ENTRY (959, "omicron",  0       			    | V40),
-    ENTRY (960, "pi",       0       			    | V40),
-    ENTRY (961, "rho",      0       			    | V40),
-    ENTRY (962, "sigmaf",   0       			    | V40),
-    ENTRY (963, "sigma",    0       			    | V40),
-    ENTRY (964, "tau",      0       			    | V40),
-    ENTRY (965, "upsilon",  0       			    | V40),
-    ENTRY (966, "phi",      0       			    | V40),
-    ENTRY (967, "chi",      0       			    | V40),
-    ENTRY (968, "psi",      0       			    | V40),
-    ENTRY (969, "omega",    0       			    | V40),
-    ENTRY (977, "thetasym", 0       			    | V40),
-    ENTRY (978, "upsih",    0       			    | V40),
-    ENTRY (982, "piv",      0       			    | V40),
-    ENTRY (8194, "ensp",    0       			    | V40),
-    ENTRY (8195, "emsp",    0       			    | V40),
-    ENTRY (8201, "thinsp",  0       			    | V40),
-    ENTRY (8204, "zwnj",    0       		| V27       | V40),
-    ENTRY (8205, "zwj",     0       		| V27       | V40),
-    ENTRY (8206, "lrm",     0       		| V27       | V40),
-    ENTRY (8207, "rlm",     0       		| V27       | V40),
-    ENTRY (8211, "ndash",   0       			    | V40),
-    ENTRY (8212, "mdash",   0       			    | V40),
-    ENTRY (8216, "lsquo",   0       			    | V40),
-    ENTRY (8217, "rsquo",   0       			    | V40),
-    ENTRY (8218, "sbquo",   0       			    | V40),
-    ENTRY (8220, "ldquo",   0       			    | V40),
-    ENTRY (8221, "rdquo",   0       			    | V40),
-    ENTRY (8222, "bdquo",   0       			    | V40),
-    ENTRY (8224, "dagger",  0       			    | V40),
-    ENTRY (8225, "Dagger",  0       			    | V40),
-    ENTRY (8226, "bull",    0       			    | V40),
-    ENTRY (8230, "hellip",  0       			    | V40),
-    ENTRY (8240, "permil",  0       			    | V40),
-    ENTRY (8242, "prime",   0       			    | V40),
-    ENTRY (8243, "Prime",   0       			    | V40),
-    ENTRY (8249, "lsaquo",  0       			    | V40),
-    ENTRY (8250, "rsaquo",  0       			    | V40),
-    ENTRY (8254, "oline",   0       			    | V40),
-    ENTRY (8260, "frasl",   0       			    | V40),
-    ENTRY (8364, "euro",    0       			    | V40),
-    ENTRY (8465, "image",   0       			    | V40),
-    ENTRY (8472, "weierp",  0       			    | V40),
-    ENTRY (8476, "real",    0       			    | V40),
-    ENTRY (8482, "trade",   0       			    | V40),
-    ENTRY (8501, "alefsym", 0       			    | V40),
-    ENTRY (8592, "larr",    0       			    | V40),
-    ENTRY (8593, "uarr",    0       			    | V40),
-    ENTRY (8594, "rarr",    0       			    | V40),
-    ENTRY (8595, "darr",    0       			    | V40),
-    ENTRY (8596, "harr",    0       			    | V40),
-    ENTRY (8629, "crarr",   0       			    | V40),
-    ENTRY (8656, "lArr",    0       			    | V40),
-    ENTRY (8657, "uArr",    0       			    | V40),
-    ENTRY (8658, "rArr",    0       			    | V40),
-    ENTRY (8659, "dArr",    0       			    | V40),
-    ENTRY (8660, "hArr",    0       			    | V40),
-    ENTRY (8704, "forall",  0       			    | V40),
-    ENTRY (8706, "part",    0       			    | V40),
-    ENTRY (8707, "exist",   0       			    | V40),
-    ENTRY (8709, "empty",   0       			    | V40),
-    ENTRY (8711, "nabla",   0       			    | V40),
-    ENTRY (8712, "isin",    0       			    | V40),
-    ENTRY (8713, "notin",   0       			    | V40),
-    ENTRY (8715, "ni",      0       			    | V40),
-    ENTRY (8719, "prod",    0       			    | V40),
-    ENTRY (8721, "sum",     0       			    | V40),
-    ENTRY (8722, "minus",   0       			    | V40),
-    ENTRY (8727, "lowast",  0       			    | V40),
-    ENTRY (8730, "radic",   0       			    | V40),
-    ENTRY (8733, "prop",    0       			    | V40),
-    ENTRY (8734, "infin",   0       			    | V40),
-    ENTRY (8736, "ang",     0       			    | V40),
-    ENTRY (8743, "and",     0       			    | V40),
-    ENTRY (8744, "or",      0       			    | V40),
-    ENTRY (8745, "cap",     0       			    | V40),
-    ENTRY (8746, "cup",     0       			    | V40),
-    ENTRY (8747, "int",     0       			    | V40),
-    ENTRY (8756, "there4",  0       			    | V40),
-    ENTRY (8764, "sim",     0       			    | V40),
-    ENTRY (8773, "cong",    0       			    | V40),
-    ENTRY (8776, "asymp",   0       			    | V40),
-    ENTRY (8800, "ne",      0       			    | V40),
-    ENTRY (8801, "equiv",   0       			    | V40),
-    ENTRY (8804, "le",      0       			    | V40),
-    ENTRY (8805, "ge",      0       			    | V40),
-    ENTRY (8834, "sub",     0       			    | V40),
-    ENTRY (8835, "sup",     0       			    | V40),
-    ENTRY (8836, "nsub",    0       			    | V40),
-    ENTRY (8838, "sube",    0       			    | V40),
-    ENTRY (8839, "supe",    0       			    | V40),
-    ENTRY (8853, "oplus",   0       			    | V40),
-    ENTRY (8855, "otimes",  0       			    | V40),
-    ENTRY (8869, "perp",    0       			    | V40),
-    ENTRY (8901, "sdot",    0       			    | V40),
-    ENTRY (8968, "lceil",   0       			    | V40),
-    ENTRY (8969, "rceil",   0       			    | V40),
-    ENTRY (8970, "lfloor",  0       			    | V40),
-    ENTRY (8971, "rfloor",  0       			    | V40),
-    ENTRY (9001, "lang",    0       			    | V40),
-    ENTRY (9002, "rang",    0       			    | V40),
-    ENTRY (9674, "loz",     0       			    | V40),
-    ENTRY (9824, "spades",  0       			    | V40),
-    ENTRY (9827, "clubs",   0       			    | V40),
-    ENTRY (9829, "hearts",  0       			    | V40),
-    ENTRY (9830, "diams",   0       			    | V40),
-    ENTRY (0,    NULL,      0       				 )
+    ENTRY (255, "yuml",     0             | V20 | V27 | V32 | V40),
+    ENTRY (338, "OElig",    0                               | V40),
+    ENTRY (339, "oelig",    0                               | V40),
+    ENTRY (352, "Scaron",   0                               | V40),
+    ENTRY (353, "scaron",   0                               | V40),
+    ENTRY (376, "Yuml",     0                               | V40),
+    ENTRY (402, "fnof",     0                               | V40),
+    ENTRY (710, "circ",     0                               | V40),
+    ENTRY (732, "tilde",    0                               | V40),
+    ENTRY (913, "Alpha",    0                               | V40),
+    ENTRY (914, "Beta",     0                               | V40),
+    ENTRY (915, "Gamma",    0                               | V40),
+    ENTRY (916, "Delta",    0                               | V40),
+    ENTRY (917, "Epsilon",  0                               | V40),
+    ENTRY (918, "Zeta",     0                               | V40),
+    ENTRY (919, "Eta",      0                               | V40),
+    ENTRY (920, "Theta",    0                               | V40),
+    ENTRY (921, "Iota",     0                               | V40),
+    ENTRY (922, "Kappa",    0                               | V40),
+    ENTRY (923, "Lambda",   0                               | V40),
+    ENTRY (924, "Mu",       0                               | V40),
+    ENTRY (925, "Nu",       0                               | V40),
+    ENTRY (926, "Xi",       0                               | V40),
+    ENTRY (927, "Omicron",  0                               | V40),
+    ENTRY (928, "Pi",       0                               | V40),
+    ENTRY (929, "Rho",      0                               | V40),
+    ENTRY (931, "Sigma",    0                               | V40),
+    ENTRY (932, "Tau",      0                               | V40),
+    ENTRY (933, "Upsilon",  0                               | V40),
+    ENTRY (934, "Phi",      0                               | V40),
+    ENTRY (935, "Chi",      0                               | V40),
+    ENTRY (936, "Psi",      0                               | V40),
+    ENTRY (937, "Omega",    0                               | V40),
+    ENTRY (945, "alpha",    0                               | V40),
+    ENTRY (946, "beta",     0                               | V40),
+    ENTRY (947, "gamma",    0                               | V40),
+    ENTRY (948, "delta",    0                               | V40),
+    ENTRY (949, "epsilon",  0                               | V40),
+    ENTRY (950, "zeta",     0                               | V40),
+    ENTRY (951, "eta",      0                               | V40),
+    ENTRY (952, "theta",    0                               | V40),
+    ENTRY (953, "iota",     0                               | V40),
+    ENTRY (954, "kappa",    0                               | V40),
+    ENTRY (955, "lambda",   0                               | V40),
+    ENTRY (956, "mu",       0                               | V40),
+    ENTRY (957, "nu",       0                               | V40),
+    ENTRY (958, "xi",       0                               | V40),
+    ENTRY (959, "omicron",  0                               | V40),
+    ENTRY (960, "pi",       0                               | V40),
+    ENTRY (961, "rho",      0                               | V40),
+    ENTRY (962, "sigmaf",   0                               | V40),
+    ENTRY (963, "sigma",    0                               | V40),
+    ENTRY (964, "tau",      0                               | V40),
+    ENTRY (965, "upsilon",  0                               | V40),
+    ENTRY (966, "phi",      0                               | V40),
+    ENTRY (967, "chi",      0                               | V40),
+    ENTRY (968, "psi",      0                               | V40),
+    ENTRY (969, "omega",    0                               | V40),
+    ENTRY (977, "thetasym", 0                               | V40),
+    ENTRY (978, "upsih",    0                               | V40),
+    ENTRY (982, "piv",      0                               | V40),
+    ENTRY (8194, "ensp",    0                               | V40),
+    ENTRY (8195, "emsp",    0                               | V40),
+    ENTRY (8201, "thinsp",  0                               | V40),
+    ENTRY (8204, "zwnj",    0                   | V27       | V40),
+    ENTRY (8205, "zwj",     0                   | V27       | V40),
+    ENTRY (8206, "lrm",     0                   | V27       | V40),
+    ENTRY (8207, "rlm",     0                   | V27       | V40),
+    ENTRY (8211, "ndash",   0                               | V40),
+    ENTRY (8212, "mdash",   0                               | V40),
+    ENTRY (8216, "lsquo",   0                               | V40),
+    ENTRY (8217, "rsquo",   0                               | V40),
+    ENTRY (8218, "sbquo",   0                               | V40),
+    ENTRY (8220, "ldquo",   0                               | V40),
+    ENTRY (8221, "rdquo",   0                               | V40),
+    ENTRY (8222, "bdquo",   0                               | V40),
+    ENTRY (8224, "dagger",  0                               | V40),
+    ENTRY (8225, "Dagger",  0                               | V40),
+    ENTRY (8226, "bull",    0                               | V40),
+    ENTRY (8230, "hellip",  0                               | V40),
+    ENTRY (8240, "permil",  0                               | V40),
+    ENTRY (8242, "prime",   0                               | V40),
+    ENTRY (8243, "Prime",   0                               | V40),
+    ENTRY (8249, "lsaquo",  0                               | V40),
+    ENTRY (8250, "rsaquo",  0                               | V40),
+    ENTRY (8254, "oline",   0                               | V40),
+    ENTRY (8260, "frasl",   0                               | V40),
+    ENTRY (8364, "euro",    0                               | V40),
+    ENTRY (8465, "image",   0                               | V40),
+    ENTRY (8472, "weierp",  0                               | V40),
+    ENTRY (8476, "real",    0                               | V40),
+    ENTRY (8482, "trade",   0                               | V40),
+    ENTRY (8501, "alefsym", 0                               | V40),
+    ENTRY (8592, "larr",    0                               | V40),
+    ENTRY (8593, "uarr",    0                               | V40),
+    ENTRY (8594, "rarr",    0                               | V40),
+    ENTRY (8595, "darr",    0                               | V40),
+    ENTRY (8596, "harr",    0                               | V40),
+    ENTRY (8629, "crarr",   0                               | V40),
+    ENTRY (8656, "lArr",    0                               | V40),
+    ENTRY (8657, "uArr",    0                               | V40),
+    ENTRY (8658, "rArr",    0                               | V40),
+    ENTRY (8659, "dArr",    0                               | V40),
+    ENTRY (8660, "hArr",    0                               | V40),
+    ENTRY (8704, "forall",  0                               | V40),
+    ENTRY (8706, "part",    0                               | V40),
+    ENTRY (8707, "exist",   0                               | V40),
+    ENTRY (8709, "empty",   0                               | V40),
+    ENTRY (8711, "nabla",   0                               | V40),
+    ENTRY (8712, "isin",    0                               | V40),
+    ENTRY (8713, "notin",   0                               | V40),
+    ENTRY (8715, "ni",      0                               | V40),
+    ENTRY (8719, "prod",    0                               | V40),
+    ENTRY (8721, "sum",     0                               | V40),
+    ENTRY (8722, "minus",   0                               | V40),
+    ENTRY (8727, "lowast",  0                               | V40),
+    ENTRY (8730, "radic",   0                               | V40),
+    ENTRY (8733, "prop",    0                               | V40),
+    ENTRY (8734, "infin",   0                               | V40),
+    ENTRY (8736, "ang",     0                               | V40),
+    ENTRY (8743, "and",     0                               | V40),
+    ENTRY (8744, "or",      0                               | V40),
+    ENTRY (8745, "cap",     0                               | V40),
+    ENTRY (8746, "cup",     0                               | V40),
+    ENTRY (8747, "int",     0                               | V40),
+    ENTRY (8756, "there4",  0                               | V40),
+    ENTRY (8764, "sim",     0                               | V40),
+    ENTRY (8773, "cong",    0                               | V40),
+    ENTRY (8776, "asymp",   0                               | V40),
+    ENTRY (8800, "ne",      0                               | V40),
+    ENTRY (8801, "equiv",   0                               | V40),
+    ENTRY (8804, "le",      0                               | V40),
+    ENTRY (8805, "ge",      0                               | V40),
+    ENTRY (8834, "sub",     0                               | V40),
+    ENTRY (8835, "sup",     0                               | V40),
+    ENTRY (8836, "nsub",    0                               | V40),
+    ENTRY (8838, "sube",    0                               | V40),
+    ENTRY (8839, "supe",    0                               | V40),
+    ENTRY (8853, "oplus",   0                               | V40),
+    ENTRY (8855, "otimes",  0                               | V40),
+    ENTRY (8869, "perp",    0                               | V40),
+    ENTRY (8901, "sdot",    0                               | V40),
+    ENTRY (8968, "lceil",   0                               | V40),
+    ENTRY (8969, "rceil",   0                               | V40),
+    ENTRY (8970, "lfloor",  0                               | V40),
+    ENTRY (8971, "rfloor",  0                               | V40),
+    ENTRY (9001, "lang",    0                               | V40),
+    ENTRY (9002, "rang",    0                               | V40),
+    ENTRY (9674, "loz",     0                               | V40),
+    ENTRY (9824, "spades",  0                               | V40),
+    ENTRY (9827, "clubs",   0                               | V40),
+    ENTRY (9829, "hearts",  0                               | V40),
+    ENTRY (9830, "diams",   0                               | V40),
+    ENTRY (0,    NULL,      0                                    )
   };
 
 #undef ENTRY
@@ -418,10 +418,10 @@ code_compare (const void *void_first, const void *void_second)
 
 static bool
 init_ucs2_html (RECODE_STEP step,
-		RECODE_CONST_REQUEST request,
-		RECODE_CONST_OPTION_LIST before_options,
-		RECODE_CONST_OPTION_LIST after_options,
-		unsigned mask)
+                RECODE_CONST_REQUEST request,
+                RECODE_CONST_OPTION_LIST before_options,
+                RECODE_CONST_OPTION_LIST after_options,
+                unsigned mask)
 {
   Hash_table *table;
   struct ucs2_to_string const *cursor;
@@ -435,12 +435,12 @@ init_ucs2_html (RECODE_STEP step,
 
   for (cursor = translations; cursor->code; cursor++)
     if (cursor->flags & mask
-	&& (!request->diacritics_only || cursor->code > 128))
+        && (!request->diacritics_only || cursor->code > 128))
       if (!hash_insert (table, cursor))
-	{
-	  hash_free (table);
-	  return false;
-	}
+        {
+          hash_free (table);
+          return false;
+        }
 
   step->step_type = RECODE_UCS2_TO_STRING;
   step->step_table = table;
@@ -450,9 +450,9 @@ init_ucs2_html (RECODE_STEP step,
 
 static bool
 init_ucs2_html_v00 (RECODE_STEP step,
-		    RECODE_CONST_REQUEST request,
-		    RECODE_CONST_OPTION_LIST before_options,
-		    RECODE_CONST_OPTION_LIST after_options)
+                    RECODE_CONST_REQUEST request,
+                    RECODE_CONST_OPTION_LIST before_options,
+                    RECODE_CONST_OPTION_LIST after_options)
 {
   return
     init_ucs2_html (step, request, before_options, after_options, V00);
@@ -460,9 +460,9 @@ init_ucs2_html_v00 (RECODE_STEP step,
 
 static bool
 init_ucs2_html_v11 (RECODE_STEP step,
-		    RECODE_CONST_REQUEST request,
-		    RECODE_CONST_OPTION_LIST before_options,
-		    RECODE_CONST_OPTION_LIST after_options)
+                    RECODE_CONST_REQUEST request,
+                    RECODE_CONST_OPTION_LIST before_options,
+                    RECODE_CONST_OPTION_LIST after_options)
 {
   return
     init_ucs2_html (step, request, before_options, after_options, V11);
@@ -470,9 +470,9 @@ init_ucs2_html_v11 (RECODE_STEP step,
 
 static bool
 init_ucs2_html_v20 (RECODE_STEP step,
-		    RECODE_CONST_REQUEST request,
-		    RECODE_CONST_OPTION_LIST before_options,
-		    RECODE_CONST_OPTION_LIST after_options)
+                    RECODE_CONST_REQUEST request,
+                    RECODE_CONST_OPTION_LIST before_options,
+                    RECODE_CONST_OPTION_LIST after_options)
 {
   return
     init_ucs2_html (step, request, before_options, after_options, V20);
@@ -480,9 +480,9 @@ init_ucs2_html_v20 (RECODE_STEP step,
 
 static bool
 init_ucs2_html_v27 (RECODE_STEP step,
-		    RECODE_CONST_REQUEST request,
-		    RECODE_CONST_OPTION_LIST before_options,
-		    RECODE_CONST_OPTION_LIST after_options)
+                    RECODE_CONST_REQUEST request,
+                    RECODE_CONST_OPTION_LIST before_options,
+                    RECODE_CONST_OPTION_LIST after_options)
 {
   return
     init_ucs2_html (step, request, before_options, after_options, V27);
@@ -490,9 +490,9 @@ init_ucs2_html_v27 (RECODE_STEP step,
 
 static bool
 init_ucs2_html_v32 (RECODE_STEP step,
-		    RECODE_CONST_REQUEST request,
-		    RECODE_CONST_OPTION_LIST before_options,
-		    RECODE_CONST_OPTION_LIST after_options)
+                    RECODE_CONST_REQUEST request,
+                    RECODE_CONST_OPTION_LIST before_options,
+                    RECODE_CONST_OPTION_LIST after_options)
 {
   return
     init_ucs2_html (step, request, before_options, after_options, V32);
@@ -500,9 +500,9 @@ init_ucs2_html_v32 (RECODE_STEP step,
 
 static bool
 init_ucs2_html_v40 (RECODE_STEP step,
-		    RECODE_CONST_REQUEST request,
-		    RECODE_CONST_OPTION_LIST before_options,
-		    RECODE_CONST_OPTION_LIST after_options)
+                    RECODE_CONST_REQUEST request,
+                    RECODE_CONST_OPTION_LIST before_options,
+                    RECODE_CONST_OPTION_LIST after_options)
 {
   return
     init_ucs2_html (step, request, before_options, after_options, V40);
@@ -526,36 +526,36 @@ transform_ucs2_html (RECODE_SUBTASK subtask)
       lookup.code = value;
       entry = (struct ucs2_to_string *) hash_lookup (table, &lookup);
       if (entry)
-	{
-	  const char *cursor = entry->string;
+        {
+          const char *cursor = entry->string;
 
-	  put_byte ('&', subtask);
-	  while (*cursor)
-	    {
-	      put_byte (*cursor, subtask);
-	      cursor++;
-	    }
-	  put_byte (';', subtask);
-	}
+          put_byte ('&', subtask);
+          while (*cursor)
+            {
+              put_byte (*cursor, subtask);
+              cursor++;
+            }
+          put_byte (';', subtask);
+        }
       else if ((value < 32 && value != '\n' && value != '\t') || value >= 127)
-	{
-	  unsigned divider = 10000;
+        {
+          unsigned divider = 10000;
 
-	  put_byte ('&', subtask);
-	  put_byte ('#', subtask);
-	  while (divider > value)
-	    divider /= 10;
-	  while (divider > 1)
-	    {
-	      put_byte ('0' + value / divider, subtask);
-	      value %= divider;
-	      divider /= 10;
-	    }
-	  put_byte ('0' + value, subtask);
-	  put_byte (';', subtask);
-	}
+          put_byte ('&', subtask);
+          put_byte ('#', subtask);
+          while (divider > value)
+            divider /= 10;
+          while (divider > 1)
+            {
+              put_byte ('0' + value / divider, subtask);
+              value %= divider;
+              divider /= 10;
+            }
+          put_byte ('0' + value, subtask);
+          put_byte (';', subtask);
+        }
       else
-	put_byte(value, subtask);
+        put_byte(value, subtask);
     }
 
   SUBTASK_RETURN (subtask);
@@ -566,10 +566,10 @@ transform_ucs2_html (RECODE_SUBTASK subtask)
 #define ENTITY_BUFFER_LENGTH 20
 
 /*
-&quot;	{ if (request->diacritics_only) ECHO; else put_ucs2 (34, subtask); }
-&amp;	{ if (request->diacritics_only) ECHO; else put_ucs2 (38, subtask); }
-&lt;	{ if (request->diacritics_only) ECHO; else put_ucs2 (60, subtask); }
-&gt;	{ if (request->diacritics_only) ECHO; else put_ucs2 (62, subtask); }
+&quot;  { if (request->diacritics_only) ECHO; else put_ucs2 (34, subtask); }
+&amp;   { if (request->diacritics_only) ECHO; else put_ucs2 (38, subtask); }
+&lt;    { if (request->diacritics_only) ECHO; else put_ucs2 (60, subtask); }
+&gt;    { if (request->diacritics_only) ECHO; else put_ucs2 (62, subtask); }
 */
 
 /*-------------------------------------.
@@ -603,10 +603,10 @@ string_compare (const void *void_first, const void *void_second)
 
 static bool
 init_html_ucs2 (RECODE_STEP step,
-		RECODE_CONST_REQUEST request,
-		RECODE_CONST_OPTION_LIST before_options,
-		RECODE_CONST_OPTION_LIST after_options,
-		unsigned mask)
+                RECODE_CONST_REQUEST request,
+                RECODE_CONST_OPTION_LIST before_options,
+                RECODE_CONST_OPTION_LIST after_options,
+                unsigned mask)
 {
   Hash_table *table;
   struct ucs2_to_string const *cursor;
@@ -620,12 +620,12 @@ init_html_ucs2 (RECODE_STEP step,
 
   for (cursor = translations; cursor->code; cursor++)
     if (cursor->flags & mask
-	&& (!request->diacritics_only || cursor->code > 128))
+        && (!request->diacritics_only || cursor->code > 128))
       if (!hash_insert (table, cursor))
-	{
-	  hash_free (table);
-	  return false;
-	}
+        {
+          hash_free (table);
+          return false;
+        }
 
   step->step_type = RECODE_STRING_TO_UCS2;
   step->step_table = table;
@@ -635,9 +635,9 @@ init_html_ucs2 (RECODE_STEP step,
 
 static bool
 init_html_v00_ucs2 (RECODE_STEP step,
-		    RECODE_CONST_REQUEST request,
-		    RECODE_CONST_OPTION_LIST before_options,
-		    RECODE_CONST_OPTION_LIST after_options)
+                    RECODE_CONST_REQUEST request,
+                    RECODE_CONST_OPTION_LIST before_options,
+                    RECODE_CONST_OPTION_LIST after_options)
 {
   return
     init_html_ucs2 (step, request, before_options, after_options, V00);
@@ -645,9 +645,9 @@ init_html_v00_ucs2 (RECODE_STEP step,
 
 static bool
 init_html_v11_ucs2 (RECODE_STEP step,
-		    RECODE_CONST_REQUEST request,
-		    RECODE_CONST_OPTION_LIST before_options,
-		    RECODE_CONST_OPTION_LIST after_options)
+                    RECODE_CONST_REQUEST request,
+                    RECODE_CONST_OPTION_LIST before_options,
+                    RECODE_CONST_OPTION_LIST after_options)
 {
   return
     init_html_ucs2 (step, request, before_options, after_options, V11);
@@ -655,9 +655,9 @@ init_html_v11_ucs2 (RECODE_STEP step,
 
 static bool
 init_html_v20_ucs2 (RECODE_STEP step,
-		    RECODE_CONST_REQUEST request,
-		    RECODE_CONST_OPTION_LIST before_options,
-		    RECODE_CONST_OPTION_LIST after_options)
+                    RECODE_CONST_REQUEST request,
+                    RECODE_CONST_OPTION_LIST before_options,
+                    RECODE_CONST_OPTION_LIST after_options)
 {
   return
     init_html_ucs2 (step, request, before_options, after_options, V20);
@@ -665,9 +665,9 @@ init_html_v20_ucs2 (RECODE_STEP step,
 
 static bool
 init_html_v27_ucs2 (RECODE_STEP step,
-		    RECODE_CONST_REQUEST request,
-		    RECODE_CONST_OPTION_LIST before_options,
-		    RECODE_CONST_OPTION_LIST after_options)
+                    RECODE_CONST_REQUEST request,
+                    RECODE_CONST_OPTION_LIST before_options,
+                    RECODE_CONST_OPTION_LIST after_options)
 {
   return
     init_html_ucs2 (step, request, before_options, after_options, V27);
@@ -675,9 +675,9 @@ init_html_v27_ucs2 (RECODE_STEP step,
 
 static bool
 init_html_v32_ucs2 (RECODE_STEP step,
-		    RECODE_CONST_REQUEST request,
-		    RECODE_CONST_OPTION_LIST before_options,
-		    RECODE_CONST_OPTION_LIST after_options)
+                    RECODE_CONST_REQUEST request,
+                    RECODE_CONST_OPTION_LIST before_options,
+                    RECODE_CONST_OPTION_LIST after_options)
 {
   return
     init_html_ucs2 (step, request, before_options, after_options, V32);
@@ -685,9 +685,9 @@ init_html_v32_ucs2 (RECODE_STEP step,
 
 static bool
 init_html_v40_ucs2 (RECODE_STEP step,
-		    RECODE_CONST_REQUEST request,
-		    RECODE_CONST_OPTION_LIST before_options,
-		    RECODE_CONST_OPTION_LIST after_options)
+                    RECODE_CONST_REQUEST request,
+                    RECODE_CONST_OPTION_LIST before_options,
+                    RECODE_CONST_OPTION_LIST after_options)
 {
   return
     init_html_ucs2 (step, request, before_options, after_options, V40);
@@ -705,7 +705,7 @@ transform_html_ucs2 (RECODE_SUBTASK subtask)
 
   input_char = get_byte (subtask);
   if (input_char != EOF)
-    put_ucs2 (BYTE_ORDER_MARK, subtask);	/* FIXME: experimental */
+    put_ucs2 (BYTE_ORDER_MARK, subtask);        /* FIXME: experimental */
 
   /* According to RFC 2718 and the Unicode Standard, if you declare the
      character encoding of your page using HTTP as either "UTF-16LE" or
@@ -717,156 +717,156 @@ transform_html_ucs2 (RECODE_SUBTASK subtask)
 
     if (input_char == '&')
       {
-	char buffer[ENTITY_BUFFER_LENGTH];
-	char *cursor = buffer;
-	bool valid = true;
-	bool echo = false;
+        char buffer[ENTITY_BUFFER_LENGTH];
+        char *cursor = buffer;
+        bool valid = true;
+        bool echo = false;
 
-	input_char = get_byte (subtask);
-	if (input_char == '#')
-	  {
-	    input_char = get_byte (subtask);
-	    if (input_char == 'x' || input_char == 'X')
-	      {
-		unsigned value = 0;
+        input_char = get_byte (subtask);
+        if (input_char == '#')
+          {
+            input_char = get_byte (subtask);
+            if (input_char == 'x' || input_char == 'X')
+              {
+                unsigned value = 0;
 
-		/* Scan &#[xX][0-9a-fA-F]+; notation.  */
+                /* Scan &#[xX][0-9a-fA-F]+; notation.  */
 
-		*cursor++ = '#';
-		*cursor++ = input_char;
-		input_char = get_byte (subtask);
+                *cursor++ = '#';
+                *cursor++ = input_char;
+                input_char = get_byte (subtask);
 
-		while (valid)
-		  {
-		    if (input_char >= '0' && input_char <= '9')
-		      value = 16 * value + input_char - '0';
-		    else if (input_char >= 'A' && input_char <= 'F')
-		      value = 16 * value + input_char - 'A' + 10;
-		    else if (input_char >= 'a' && input_char <= 'f')
-		      value = 16 * value + input_char - 'a' + 10;
-		    else
-		      break;
+                while (valid)
+                  {
+                    if (input_char >= '0' && input_char <= '9')
+                      value = 16 * value + input_char - '0';
+                    else if (input_char >= 'A' && input_char <= 'F')
+                      value = 16 * value + input_char - 'A' + 10;
+                    else if (input_char >= 'a' && input_char <= 'f')
+                      value = 16 * value + input_char - 'a' + 10;
+                    else
+                      break;
 
-		    if (value >= 65535)
-		      valid = false;
-		    else if (cursor == buffer + ENTITY_BUFFER_LENGTH - 2)
-		      valid = false;
-		    else
-		      {
-			*cursor++ = input_char;
-			input_char = get_byte (subtask);
-		      }
-		  }
+                    if (value >= 65535)
+                      valid = false;
+                    else if (cursor == buffer + ENTITY_BUFFER_LENGTH - 2)
+                      valid = false;
+                    else
+                      {
+                        *cursor++ = input_char;
+                        input_char = get_byte (subtask);
+                      }
+                  }
 
-		if (valid)
-		  if (request->diacritics_only)
-		    {
-		      echo = true;
-		      *cursor = '\0';
-		    }
-		  else
-		    {
-		      put_ucs2 (value, subtask);
-		      if (input_char == ';')
-			input_char = get_byte (subtask);
-		    }
-		else
-		  *cursor = '\0';
-	      }
-	    else
-	      {
-		unsigned value = 0;
+                if (valid)
+                  if (request->diacritics_only)
+                    {
+                      echo = true;
+                      *cursor = '\0';
+                    }
+                  else
+                    {
+                      put_ucs2 (value, subtask);
+                      if (input_char == ';')
+                        input_char = get_byte (subtask);
+                    }
+                else
+                  *cursor = '\0';
+              }
+            else
+              {
+                unsigned value = 0;
 
-		/* Scan &#[0-9]+; notation.  */
+                /* Scan &#[0-9]+; notation.  */
 
-		*cursor++ = '#';
+                *cursor++ = '#';
 
-		while (valid)
-		  {
-		    if (input_char >= '0' && input_char <= '9')
-		      value = 10 * value + input_char - '0';
-		    else
-		      break;
+                while (valid)
+                  {
+                    if (input_char >= '0' && input_char <= '9')
+                      value = 10 * value + input_char - '0';
+                    else
+                      break;
 
-		    if (value >= 65535)
-		      valid = false;
-		    else if (cursor == buffer + ENTITY_BUFFER_LENGTH - 2)
-		      valid = false;
-		    else
-		      {
-			*cursor++ = input_char;
-			input_char = get_byte (subtask);
-		      }
-		  }
+                    if (value >= 65535)
+                      valid = false;
+                    else if (cursor == buffer + ENTITY_BUFFER_LENGTH - 2)
+                      valid = false;
+                    else
+                      {
+                        *cursor++ = input_char;
+                        input_char = get_byte (subtask);
+                      }
+                  }
 
-		if (valid)
-		  if (request->diacritics_only)
-		    {
-		      echo = true;
-		      *cursor = '\0';
-		    }
-		  else
-		    {
-		      put_ucs2 (value, subtask);
-		      if (input_char == ';')
-			input_char = get_byte (subtask);
-		    }
-		else
-		  *cursor = '\0';
-	      }
-	  }
-	else if ((input_char >= 'A' && input_char <= 'Z')
-		 || (input_char >= 'a' && input_char <= 'z'))
-	  {
-	    /* Scan &[A-Za-z][A-Za-z0-9]*; notation.  */
+                if (valid)
+                  if (request->diacritics_only)
+                    {
+                      echo = true;
+                      *cursor = '\0';
+                    }
+                  else
+                    {
+                      put_ucs2 (value, subtask);
+                      if (input_char == ';')
+                        input_char = get_byte (subtask);
+                    }
+                else
+                  *cursor = '\0';
+              }
+          }
+        else if ((input_char >= 'A' && input_char <= 'Z')
+                 || (input_char >= 'a' && input_char <= 'z'))
+          {
+            /* Scan &[A-Za-z][A-Za-z0-9]*; notation.  */
 
-	    *cursor++ = input_char;
-	    input_char = get_byte (subtask);
+            *cursor++ = input_char;
+            input_char = get_byte (subtask);
 
-	    while (valid
-		   && input_char != EOF
-		   && ((input_char >= 'A' && input_char <= 'Z')
-		       || (input_char >= 'a' && input_char <= 'z')
-		       || (input_char >= '0' && input_char <= '9')))
-	      if (cursor == buffer + ENTITY_BUFFER_LENGTH - 2)
-		valid = false;
-	      else
-		{
-		  *cursor++ = input_char;
-		  input_char = get_byte (subtask);
-		}
-	    *cursor = '\0';
+            while (valid
+                   && input_char != EOF
+                   && ((input_char >= 'A' && input_char <= 'Z')
+                       || (input_char >= 'a' && input_char <= 'z')
+                       || (input_char >= '0' && input_char <= '9')))
+              if (cursor == buffer + ENTITY_BUFFER_LENGTH - 2)
+                valid = false;
+              else
+                {
+                  *cursor++ = input_char;
+                  input_char = get_byte (subtask);
+                }
+            *cursor = '\0';
 
-	    if (valid)
-	      {
-		struct ucs2_to_string lookup;
-		struct ucs2_to_string *entry;
+            if (valid)
+              {
+                struct ucs2_to_string lookup;
+                struct ucs2_to_string *entry;
 
-		lookup.string = buffer;
-		entry = (struct ucs2_to_string *) hash_lookup
-		  ((const Hash_table *) subtask->step->step_table, &lookup);
-		if (entry)
-		  {
-		    put_ucs2 (entry->code, subtask);
-		    if (input_char == ';')
-		      input_char = get_byte (subtask);
-		  }
-		else
-		  valid = false;
-	      }
-	  }
+                lookup.string = buffer;
+                entry = (struct ucs2_to_string *) hash_lookup
+                  ((const Hash_table *) subtask->step->step_table, &lookup);
+                if (entry)
+                  {
+                    put_ucs2 (entry->code, subtask);
+                    if (input_char == ';')
+                      input_char = get_byte (subtask);
+                  }
+                else
+                  valid = false;
+              }
+          }
 
-	if (echo || !valid)
-	  {
-	    put_ucs2 ('&', subtask);
-	    for (cursor = buffer; *cursor; cursor++)
-	      put_ucs2 (*cursor, subtask);
-	  }
+        if (echo || !valid)
+          {
+            put_ucs2 ('&', subtask);
+            for (cursor = buffer; *cursor; cursor++)
+              put_ucs2 (*cursor, subtask);
+          }
       }
     else
       {
-	put_ucs2 (input_char, subtask);
-	input_char = get_byte (subtask);
+        put_ucs2 (input_char, subtask);
+        input_char = get_byte (subtask);
       }
 
   SUBTASK_RETURN (subtask);
@@ -878,41 +878,41 @@ module_html (RECODE_OUTER outer)
 {
   return
     declare_single (outer, "ISO-10646-UCS-2", "XML-standalone",
-		    outer->quality_byte_to_variable,
-		    init_ucs2_html_v00, transform_ucs2_html)
+                    outer->quality_byte_to_variable,
+                    init_ucs2_html_v00, transform_ucs2_html)
     && declare_single (outer, "XML-standalone", "ISO-10646-UCS-2",
-		       outer->quality_variable_to_byte,
-		       init_html_v00_ucs2, transform_html_ucs2)
+                       outer->quality_variable_to_byte,
+                       init_html_v00_ucs2, transform_html_ucs2)
     && declare_single (outer, "ISO-10646-UCS-2", "HTML_1.1",
-		    outer->quality_byte_to_variable,
-		    init_ucs2_html_v11, transform_ucs2_html)
+                    outer->quality_byte_to_variable,
+                    init_ucs2_html_v11, transform_ucs2_html)
     && declare_single (outer, "HTML_1.1", "ISO-10646-UCS-2",
-		       outer->quality_variable_to_byte,
-		       init_html_v11_ucs2, transform_html_ucs2)
+                       outer->quality_variable_to_byte,
+                       init_html_v11_ucs2, transform_html_ucs2)
     && declare_single (outer, "ISO-10646-UCS-2", "HTML_2.0",
-		       outer->quality_byte_to_variable,
-		       init_ucs2_html_v20, transform_ucs2_html)
+                       outer->quality_byte_to_variable,
+                       init_ucs2_html_v20, transform_ucs2_html)
     && declare_single (outer, "HTML_2.0", "ISO-10646-UCS-2",
-		       outer->quality_variable_to_byte,
-		       init_html_v20_ucs2, transform_html_ucs2)
+                       outer->quality_variable_to_byte,
+                       init_html_v20_ucs2, transform_html_ucs2)
     && declare_single (outer, "ISO-10646-UCS-2", "HTML-i18n",
-		       outer->quality_byte_to_variable,
-		       init_ucs2_html_v27, transform_ucs2_html)
+                       outer->quality_byte_to_variable,
+                       init_ucs2_html_v27, transform_ucs2_html)
     && declare_single (outer, "HTML-i18n", "ISO-10646-UCS-2",
-		       outer->quality_variable_to_byte,
-		       init_html_v27_ucs2, transform_html_ucs2)
+                       outer->quality_variable_to_byte,
+                       init_html_v27_ucs2, transform_html_ucs2)
     && declare_single (outer, "ISO-10646-UCS-2", "HTML_3.2",
-		       outer->quality_byte_to_variable,
-		       init_ucs2_html_v32, transform_ucs2_html)
+                       outer->quality_byte_to_variable,
+                       init_ucs2_html_v32, transform_ucs2_html)
     && declare_single (outer, "HTML_3.2", "ISO-10646-UCS-2",
-		       outer->quality_variable_to_byte,
-		       init_html_v32_ucs2, transform_html_ucs2)
+                       outer->quality_variable_to_byte,
+                       init_html_v32_ucs2, transform_html_ucs2)
     && declare_single (outer, "ISO-10646-UCS-2", "HTML_4.0",
-		       outer->quality_byte_to_variable,
-		       init_ucs2_html_v40, transform_ucs2_html)
+                       outer->quality_byte_to_variable,
+                       init_ucs2_html_v40, transform_ucs2_html)
     && declare_single (outer, "HTML_4.0", "ISO-10646-UCS-2",
-		       outer->quality_variable_to_byte,
-		       init_html_v40_ucs2, transform_html_ucs2)
+                       outer->quality_variable_to_byte,
+                       init_html_v40_ucs2, transform_html_ucs2)
 
     && declare_alias (outer, "h0", "XML-standalone")
     && declare_alias (outer, "h1", "HTML_1.1")

--- a/src/ibmpc.c
+++ b/src/ibmpc.c
@@ -26,9 +26,9 @@
    built-in code.  For now, depend on a variable preset to false.  */
 static const bool auto_crlf = false;
 
-#define DOS_EOF 26		/* oldish end of file */
-#define DOS_CR 13		/* carriage return */
-#define DOS_LF 10		/* line feed */
+#define DOS_EOF 26              /* oldish end of file */
+#define DOS_CR 13               /* carriage return */
+#define DOS_LF 10               /* line feed */
 
 /* Correspondance for IBM PC ruler graphics characters into ASCII graphics
    approximations.  The current principles are:
@@ -45,126 +45,126 @@ static const bool auto_crlf = false;
 
 unsigned char convert_rulers[48] =
   {
-    '#',			/* 176 */
-    '#',			/* 177 */
-    '#',			/* 178 */
-    '|',			/* 179 */
-    '+',			/* 180 */
-    '|',			/* 181 */
-    '+',			/* 182 */
-    '.',			/* 183 */
-    '.',			/* 184 */
-    '|',			/* 185 */
-    '|',			/* 186 */
-    '.',			/* 187 */
-    '\'',			/* 188 */
-    '\'',			/* 189 */
-    '\'',			/* 190 */
-    '.',			/* 191 */
-    '`',			/* 192 */
-    '+',			/* 193 */
-    '+',			/* 194 */
-    '+',			/* 195 */
-    '-',			/* 196 */
-    '+',			/* 197 */
-    '|',			/* 198 */
-    '+',			/* 199 */
-    '`',			/* 200 */
-    '.',			/* 201 */
-    '=',			/* 202 */
-    '=',			/* 203 */
-    '|',			/* 204 */
-    '=',			/* 205 */
-    '=',			/* 206 */
-    '=',			/* 207 */
-    '+',			/* 208 */
-    '=',			/* 209 */
-    '+',			/* 210 */
-    '`',			/* 211 */
-    '`',			/* 212 */
-    '.',			/* 213 */
-    '.',			/* 214 */
-    '+',			/* 215 */
-    '=',			/* 216 */
-    '\'',			/* 217 */
-    '.',			/* 218 */
-    '#',			/* 219 */
-    '#',			/* 220 */
-    '#',			/* 221 */
-    '#',			/* 222 */
-    '#',			/* 223 */
+    '#',                        /* 176 */
+    '#',                        /* 177 */
+    '#',                        /* 178 */
+    '|',                        /* 179 */
+    '+',                        /* 180 */
+    '|',                        /* 181 */
+    '+',                        /* 182 */
+    '.',                        /* 183 */
+    '.',                        /* 184 */
+    '|',                        /* 185 */
+    '|',                        /* 186 */
+    '.',                        /* 187 */
+    '\'',                       /* 188 */
+    '\'',                       /* 189 */
+    '\'',                       /* 190 */
+    '.',                        /* 191 */
+    '`',                        /* 192 */
+    '+',                        /* 193 */
+    '+',                        /* 194 */
+    '+',                        /* 195 */
+    '-',                        /* 196 */
+    '+',                        /* 197 */
+    '|',                        /* 198 */
+    '+',                        /* 199 */
+    '`',                        /* 200 */
+    '.',                        /* 201 */
+    '=',                        /* 202 */
+    '=',                        /* 203 */
+    '|',                        /* 204 */
+    '=',                        /* 205 */
+    '=',                        /* 206 */
+    '=',                        /* 207 */
+    '+',                        /* 208 */
+    '=',                        /* 209 */
+    '+',                        /* 210 */
+    '`',                        /* 211 */
+    '`',                        /* 212 */
+    '.',                        /* 213 */
+    '.',                        /* 214 */
+    '+',                        /* 215 */
+    '=',                        /* 216 */
+    '\'',                       /* 217 */
+    '.',                        /* 218 */
+    '#',                        /* 219 */
+    '#',                        /* 220 */
+    '#',                        /* 221 */
+    '#',                        /* 222 */
+    '#',                        /* 223 */
   };
 
 /* Data for IBM PC to ISO Latin-1 code conversions.  */
 
 static struct recode_known_pair known_pairs[] =
   {
-    { 20, 182},			/* pilcrow sign */
-    { 21, 167},			/* section sign */
+    { 20, 182},                 /* pilcrow sign */
+    { 21, 167},                 /* section sign */
 
-    {128, 199},			/* capital letter C with cedilla */
-    {129, 252},			/* small letter u with diaeresis */
-    {130, 233},			/* small letter e with acute accent */
-    {131, 226},			/* small letter a with circumflex accent */
-    {132, 228},			/* small letter a with diaeresis */
-    {133, 224},			/* small letter a with grave accent */
-    {134, 229},			/* small letter a with ring above */
-    {135, 231},			/* small letter c with cedilla */
-    {136, 234},			/* small letter e with circumflex accent */
-    {137, 235},			/* small letter e with diaeresis */
-    {138, 232},			/* small letter e with grave accent */
-    {139, 239},			/* small letter i with diaeresis */
-    {140, 238},			/* small letter i with circumflex accent */
-    {141, 236},			/* small letter i with grave accent */
-    {142, 196},			/* capital letter A with diaeresis */
-    {143, 197},			/* capital letter A with ring above */
-    {144, 201},			/* capital letter E with acute accent */
-    {145, 230},			/* small ligature a with e */
-    {146, 198},			/* capital ligature A with E */
-    {147, 244},			/* small letter o with circumblex accent */
-    {148, 246},			/* small letter o with diaeresis */
-    {149, 242},			/* small letter o with grave accent */
-    {150, 251},			/* small letter u with circumflex accent */
-    {151, 249},			/* small letter u with grave accent */
-    {152, 255},			/* small letter y with diaeresis */
-    {153, 214},			/* capital letter O with diaeresis */
-    {154, 220},			/* capital letter U with diaeresis */
-    {155, 162},			/* cent sign */
-    {156, 163},			/* pound sign */
-    {157, 165},			/* yen sign */
+    {128, 199},                 /* capital letter C with cedilla */
+    {129, 252},                 /* small letter u with diaeresis */
+    {130, 233},                 /* small letter e with acute accent */
+    {131, 226},                 /* small letter a with circumflex accent */
+    {132, 228},                 /* small letter a with diaeresis */
+    {133, 224},                 /* small letter a with grave accent */
+    {134, 229},                 /* small letter a with ring above */
+    {135, 231},                 /* small letter c with cedilla */
+    {136, 234},                 /* small letter e with circumflex accent */
+    {137, 235},                 /* small letter e with diaeresis */
+    {138, 232},                 /* small letter e with grave accent */
+    {139, 239},                 /* small letter i with diaeresis */
+    {140, 238},                 /* small letter i with circumflex accent */
+    {141, 236},                 /* small letter i with grave accent */
+    {142, 196},                 /* capital letter A with diaeresis */
+    {143, 197},                 /* capital letter A with ring above */
+    {144, 201},                 /* capital letter E with acute accent */
+    {145, 230},                 /* small ligature a with e */
+    {146, 198},                 /* capital ligature A with E */
+    {147, 244},                 /* small letter o with circumblex accent */
+    {148, 246},                 /* small letter o with diaeresis */
+    {149, 242},                 /* small letter o with grave accent */
+    {150, 251},                 /* small letter u with circumflex accent */
+    {151, 249},                 /* small letter u with grave accent */
+    {152, 255},                 /* small letter y with diaeresis */
+    {153, 214},                 /* capital letter O with diaeresis */
+    {154, 220},                 /* capital letter U with diaeresis */
+    {155, 162},                 /* cent sign */
+    {156, 163},                 /* pound sign */
+    {157, 165},                 /* yen sign */
 
-    {160, 225},			/* small letter a with acute accent */
-    {161, 237},			/* small letter i with acute accent */
-    {162, 243},			/* small letter o with acute accent */
-    {163, 250},			/* small letter u with acute accent */
-    {164, 241},			/* small letter n with tilde */
-    {165, 209},			/* capital letter N with tilde */
-    {166, 170},			/* feminine ordinal indicator */
-    {167, 186},			/* masculine ordinal indicator */
-    {168, 191},			/* inverted question mark */
+    {160, 225},                 /* small letter a with acute accent */
+    {161, 237},                 /* small letter i with acute accent */
+    {162, 243},                 /* small letter o with acute accent */
+    {163, 250},                 /* small letter u with acute accent */
+    {164, 241},                 /* small letter n with tilde */
+    {165, 209},                 /* capital letter N with tilde */
+    {166, 170},                 /* feminine ordinal indicator */
+    {167, 186},                 /* masculine ordinal indicator */
+    {168, 191},                 /* inverted question mark */
 
-    {170, 172},			/* not sign */
-    {171, 189},			/* vulgar fraction one half */
-    {172, 188},			/* vulgar fraction one quarter */
-    {173, 161},			/* inverted exclamation mark */
-    {174, 171},			/* left angle quotation mark */
-    {175, 187},			/* right angle quotation mark */
+    {170, 172},                 /* not sign */
+    {171, 189},                 /* vulgar fraction one half */
+    {172, 188},                 /* vulgar fraction one quarter */
+    {173, 161},                 /* inverted exclamation mark */
+    {174, 171},                 /* left angle quotation mark */
+    {175, 187},                 /* right angle quotation mark */
 
-    {225, 223},			/* small german letter sharp s */
+    {225, 223},                 /* small german letter sharp s */
 
-    {230, 181},			/* small Greek letter mu micro sign */
+    {230, 181},                 /* small Greek letter mu micro sign */
 
-    {241, 177},			/* plus-minus sign */
+    {241, 177},                 /* plus-minus sign */
 
-    {246, 247},			/* division sign */
+    {246, 247},                 /* division sign */
 
-    {248, 176},			/* degree sign */
+    {248, 176},                 /* degree sign */
 
-    {250, 183},			/* middle dot */
+    {250, 183},                 /* middle dot */
 
-    {253, 178},			/* superscript two */
+    {253, 178},                 /* superscript two */
 
-    {255, 160},			/* no-break space */
+    {255, 160},                 /* no-break space */
   };
 #define NUMBER_OF_PAIRS \
   (sizeof (known_pairs) / sizeof (struct recode_known_pair))
@@ -175,34 +175,34 @@ transform_latin1_ibmpc (RECODE_SUBTASK subtask)
   if (subtask->step->fallback_routine == reversibility)
     {
       const unsigned char *table
-	= (const unsigned char *) subtask->step->step_table;
+        = (const unsigned char *) subtask->step->step_table;
       int input_char;
 
       while (input_char = get_byte (subtask), input_char != EOF)
-	if (input_char == '\n')
-	  {
-	    put_byte (DOS_CR, subtask);
-	    put_byte (DOS_LF, subtask);
-	  }
-	else
-	  put_byte (table[input_char], subtask);
+        if (input_char == '\n')
+          {
+            put_byte (DOS_CR, subtask);
+            put_byte (DOS_LF, subtask);
+          }
+        else
+          put_byte (table[input_char], subtask);
     }
   else
     {
       const char *const *table
-	= (const char *const *) subtask->step->step_table;
+        = (const char *const *) subtask->step->step_table;
       int input_char;
 
       while (input_char = get_byte (subtask), input_char != EOF)
-	if (input_char == '\n')
-	  {
-	    put_byte (DOS_CR, subtask);
-	    put_byte (DOS_LF, subtask);
-	  }
-	else if (table[input_char])
-	  put_byte (*table[input_char], subtask);
-	else
-	  RETURN_IF_NOGO (RECODE_UNTRANSLATABLE, subtask);
+        if (input_char == '\n')
+          {
+            put_byte (DOS_CR, subtask);
+            put_byte (DOS_LF, subtask);
+          }
+        else if (table[input_char])
+          put_byte (*table[input_char], subtask);
+        else
+          RETURN_IF_NOGO (RECODE_UNTRANSLATABLE, subtask);
     }
   SUBTASK_RETURN (subtask);
 }
@@ -213,75 +213,75 @@ transform_ibmpc_latin1 (RECODE_SUBTASK subtask)
   if (subtask->step->fallback_routine == reversibility)
     {
       const unsigned char *table
-	= (const unsigned char *) subtask->step->step_table;
+        = (const unsigned char *) subtask->step->step_table;
       int input_char = get_byte (subtask);
 
       while (input_char != EOF)
-	switch (input_char)
-	  {
-	  case DOS_EOF:
-	    RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
-	    input_char = EOF;
-	    break;
+        switch (input_char)
+          {
+          case DOS_EOF:
+            RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
+            input_char = EOF;
+            break;
 
-	  case DOS_CR:
-	    input_char = get_byte (subtask);
-	    if (input_char == DOS_LF)
-	      {
-		put_byte ('\n', subtask);
-		input_char = get_byte (subtask);
-	      }
-	    else
-	      put_byte (table[DOS_CR], subtask);
-	    break;
+          case DOS_CR:
+            input_char = get_byte (subtask);
+            if (input_char == DOS_LF)
+              {
+                put_byte ('\n', subtask);
+                input_char = get_byte (subtask);
+              }
+            else
+              put_byte (table[DOS_CR], subtask);
+            break;
 
-	  case DOS_LF:
-	    RETURN_IF_NOGO (RECODE_AMBIGUOUS_OUTPUT, subtask);
-	    FALLTHROUGH;
+          case DOS_LF:
+            RETURN_IF_NOGO (RECODE_AMBIGUOUS_OUTPUT, subtask);
+            FALLTHROUGH;
 
-	  default:
-	    put_byte (table[input_char], subtask);
-	    input_char = get_byte (subtask);
-	  }
+          default:
+            put_byte (table[input_char], subtask);
+            input_char = get_byte (subtask);
+          }
     }
   else
     {
       const char *const *table
-	= (const char *const *) subtask->step->step_table;
+        = (const char *const *) subtask->step->step_table;
       int input_char = get_byte (subtask);
 
       while (input_char != EOF)
-	switch (input_char)
-	  {
-	  case DOS_EOF:
-	    RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
-	    input_char = EOF;
-	    break;
+        switch (input_char)
+          {
+          case DOS_EOF:
+            RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
+            input_char = EOF;
+            break;
 
-	  case DOS_CR:
-	    input_char = get_byte (subtask);
-	    if (input_char == DOS_LF)
-	      {
-		put_byte ('\n', subtask);
-		input_char = get_byte (subtask);
-	      }
-	    else if (table[DOS_CR])
-	      put_byte (*table[DOS_CR], subtask);
-	    else
-	      RETURN_IF_NOGO (RECODE_UNTRANSLATABLE, subtask);
-	    break;
+          case DOS_CR:
+            input_char = get_byte (subtask);
+            if (input_char == DOS_LF)
+              {
+                put_byte ('\n', subtask);
+                input_char = get_byte (subtask);
+              }
+            else if (table[DOS_CR])
+              put_byte (*table[DOS_CR], subtask);
+            else
+              RETURN_IF_NOGO (RECODE_UNTRANSLATABLE, subtask);
+            break;
 
-	  case DOS_LF:
-	    RETURN_IF_NOGO (RECODE_AMBIGUOUS_OUTPUT, subtask);
-	    FALLTHROUGH;
+          case DOS_LF:
+            RETURN_IF_NOGO (RECODE_AMBIGUOUS_OUTPUT, subtask);
+            FALLTHROUGH;
 
-	  default:
-	    if (table[input_char])
-	      put_byte (*table[input_char], subtask);
-	    else
-	      RETURN_IF_NOGO (RECODE_UNTRANSLATABLE, subtask);
-	    input_char = get_byte (subtask);
-	  }
+          default:
+            if (table[input_char])
+              put_byte (*table[input_char], subtask);
+            else
+              RETURN_IF_NOGO (RECODE_UNTRANSLATABLE, subtask);
+            input_char = get_byte (subtask);
+          }
     }
 
   SUBTASK_RETURN (subtask);
@@ -289,15 +289,15 @@ transform_ibmpc_latin1 (RECODE_SUBTASK subtask)
 
 static bool
 init_latin1_ibmpc (RECODE_STEP step,
-		   RECODE_CONST_REQUEST request,
-		   RECODE_CONST_OPTION_LIST before_options,
-		   RECODE_CONST_OPTION_LIST after_options)
+                   RECODE_CONST_REQUEST request,
+                   RECODE_CONST_OPTION_LIST before_options,
+                   RECODE_CONST_OPTION_LIST after_options)
 {
   if (before_options || after_options)
     return false;
 
   if (!complete_pairs (request->outer, step,
-		       known_pairs, NUMBER_OF_PAIRS, true, true))
+                       known_pairs, NUMBER_OF_PAIRS, true, true))
     return false;
 
   if (auto_crlf)
@@ -312,9 +312,9 @@ init_latin1_ibmpc (RECODE_STEP step,
 
 static bool
 init_ibmpc_latin1 (RECODE_STEP step,
-		   RECODE_CONST_REQUEST request,
-		   RECODE_CONST_OPTION_LIST before_options,
-		   RECODE_CONST_OPTION_LIST after_options)
+                   RECODE_CONST_REQUEST request,
+                   RECODE_CONST_OPTION_LIST before_options,
+                   RECODE_CONST_OPTION_LIST after_options)
 {
   RECODE_OUTER outer = request->outer;
   unsigned char *table;
@@ -323,7 +323,7 @@ init_ibmpc_latin1 (RECODE_STEP step,
     return false;
 
   if (!complete_pairs (outer, step,
-		       known_pairs, NUMBER_OF_PAIRS, true, false))
+                       known_pairs, NUMBER_OF_PAIRS, true, false))
     return false;
 
   if (auto_crlf)
@@ -339,7 +339,7 @@ init_ibmpc_latin1 (RECODE_STEP step,
   if (request->ascii_graphics)
     {
       if (!ALLOC (table, 256, unsigned char))
-	return false;
+        return false;
       memcpy (table, step->step_table, 256);
       memcpy (table + 176, convert_rulers, 48);
       free (step->step_table);
@@ -355,12 +355,12 @@ module_ibmpc (RECODE_OUTER outer)
   RECODE_ALIAS alias;
 
   if (!declare_single (outer, "Latin-1", "IBM-PC",
-		       outer->quality_byte_to_variable,
-		       init_latin1_ibmpc, transform_latin1_ibmpc))
+                       outer->quality_byte_to_variable,
+                       init_latin1_ibmpc, transform_latin1_ibmpc))
     return false;
   if (!declare_single (outer, "IBM-PC", "Latin-1",
-		       outer->quality_variable_to_variable,
-		       init_ibmpc_latin1, transform_ibmpc_latin1))
+                       outer->quality_variable_to_variable,
+                       init_ibmpc_latin1, transform_ibmpc_latin1))
     return false;
 
   if (alias = declare_alias (outer, "IBM-PC", "IBM-PC"), !alias)

--- a/src/iconqnx.c
+++ b/src/iconqnx.c
@@ -21,18 +21,18 @@
 #include "common.h"
 #include "decsteps.h"
 
-#define DOS_CR 13		/* carriage return */
-#define DOS_LF 10		/* line feed */
-#define DOS_EOF 26		/* old end of file */
+#define DOS_CR 13               /* carriage return */
+#define DOS_LF 10               /* line feed */
+#define DOS_EOF 26              /* old end of file */
 
-#define ESCAPE 25		/* escape for diacritic application */
-#define ENDLINE 30		/* end-line code for QNX */
+#define ESCAPE 25               /* escape for diacritic application */
+#define ENDLINE 30              /* end-line code for QNX */
 
 #define TRANSLATE_AND_BREAK(c2, c3) \
-  put_byte (ESCAPE, subtask);		\
-  put_byte (c2, subtask);		\
-  put_byte (c3, subtask);		\
-  input_char = get_byte (subtask);	\
+  put_byte (ESCAPE, subtask);           \
+  put_byte (c2, subtask);               \
+  put_byte (c3, subtask);               \
+  input_char = get_byte (subtask);      \
   break;
 
 static bool
@@ -45,11 +45,11 @@ transform_ibmpc_iconqnx (RECODE_SUBTASK subtask)
     switch (input_char)
       {
       case DOS_EOF:
-	RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
-	FALLTHROUGH;
+        RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
+        FALLTHROUGH;
 
       case EOF:
-	SUBTASK_RETURN (subtask);
+        SUBTASK_RETURN (subtask);
 
       case 133: TRANSLATE_AND_BREAK ('A', 'a');
       case 138: TRANSLATE_AND_BREAK ('A', 'e');
@@ -68,152 +68,152 @@ transform_ibmpc_iconqnx (RECODE_SUBTASK subtask)
       case 128: TRANSLATE_AND_BREAK ('K', 'C');
 
       case DOS_CR:
-	input_char = get_byte (subtask);
-	if (input_char == DOS_LF)
-	  {
-	    put_byte (ENDLINE, subtask);
-	    input_char = get_byte (subtask);
-	  }
-	else
-	  put_byte (DOS_CR, subtask);
-	break;
+        input_char = get_byte (subtask);
+        if (input_char == DOS_LF)
+          {
+            put_byte (ENDLINE, subtask);
+            input_char = get_byte (subtask);
+          }
+        else
+          put_byte (DOS_CR, subtask);
+        break;
 
       case ENDLINE:
       case ESCAPE:
-	RETURN_IF_NOGO (RECODE_AMBIGUOUS_OUTPUT, subtask);
-	FALLTHROUGH;
+        RETURN_IF_NOGO (RECODE_AMBIGUOUS_OUTPUT, subtask);
+        FALLTHROUGH;
 
       default:
-	put_byte (input_char, subtask);
-	input_char = get_byte (subtask);
+        put_byte (input_char, subtask);
+        input_char = get_byte (subtask);
       }
 }
 
 static bool
 transform_iconqnx_ibmpc (RECODE_SUBTASK subtask)
 {
-  int input_char;		/* current character */
+  int input_char;               /* current character */
 
   input_char = get_byte (subtask);
   while (true)
     switch (input_char)
       {
       case EOF:
-	SUBTASK_RETURN (subtask);
+        SUBTASK_RETURN (subtask);
 
       case ENDLINE:
-	put_byte (DOS_CR, subtask);
-	put_byte (DOS_LF, subtask);
-	input_char = get_byte (subtask);
-	break;
+        put_byte (DOS_CR, subtask);
+        put_byte (DOS_LF, subtask);
+        input_char = get_byte (subtask);
+        break;
 
       case DOS_CR:
-	input_char = get_byte (subtask);
-	if (input_char == DOS_LF)
-	  RETURN_IF_NOGO (RECODE_AMBIGUOUS_OUTPUT, subtask);
-	put_byte (DOS_CR, subtask);
-	break;
+        input_char = get_byte (subtask);
+        if (input_char == DOS_LF)
+          RETURN_IF_NOGO (RECODE_AMBIGUOUS_OUTPUT, subtask);
+        put_byte (DOS_CR, subtask);
+        break;
 
       case ESCAPE:
-	input_char = get_byte (subtask);
-	switch (input_char)
-	  {
-	  case 'A':
-	    input_char = get_byte (subtask);
-	    switch (input_char)
-	      {
-	      case 'a': input_char = 133; break;
-	      case 'e': input_char = 138; break;
-	      case 'u': input_char = 151; break;
+        input_char = get_byte (subtask);
+        switch (input_char)
+          {
+          case 'A':
+            input_char = get_byte (subtask);
+            switch (input_char)
+              {
+              case 'a': input_char = 133; break;
+              case 'e': input_char = 138; break;
+              case 'u': input_char = 151; break;
 
-	      default:
-		RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-		put_byte (ESCAPE, subtask);
-		put_byte ('A', subtask);
-		if (input_char == EOF)
-		  SUBTASK_RETURN (subtask);
-	      }
-	    break;
+              default:
+                RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+                put_byte (ESCAPE, subtask);
+                put_byte ('A', subtask);
+                if (input_char == EOF)
+                  SUBTASK_RETURN (subtask);
+              }
+            break;
 
-	  case 'B':
-	    input_char = get_byte (subtask);
-	    switch (input_char)
-	      {
-	      case 'e': input_char = 130; break;
-	      case 'E': input_char = 144; break;
+          case 'B':
+            input_char = get_byte (subtask);
+            switch (input_char)
+              {
+              case 'e': input_char = 130; break;
+              case 'E': input_char = 144; break;
 
-	      default:
-		RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-		put_byte (ESCAPE, subtask);
-		put_byte ('B', subtask);
-		if (input_char == EOF)
-		  SUBTASK_RETURN (subtask);
-	      }
-	    break;
+              default:
+                RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+                put_byte (ESCAPE, subtask);
+                put_byte ('B', subtask);
+                if (input_char == EOF)
+                  SUBTASK_RETURN (subtask);
+              }
+            break;
 
-	  case 'C':
-	    input_char = get_byte (subtask);
-	    switch (input_char)
-	      {
-	      case 'a': input_char = 131; break;
-	      case 'e': input_char = 136; break;
-	      case 'i': input_char = 140; break;
-	      case 'o': input_char = 147; break;
-	      case 'u': input_char = 150; break;
+          case 'C':
+            input_char = get_byte (subtask);
+            switch (input_char)
+              {
+              case 'a': input_char = 131; break;
+              case 'e': input_char = 136; break;
+              case 'i': input_char = 140; break;
+              case 'o': input_char = 147; break;
+              case 'u': input_char = 150; break;
 
-	      default:
-		RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-		put_byte (ESCAPE, subtask);
-		put_byte ('C', subtask);
-		if (input_char == EOF)
-		  SUBTASK_RETURN (subtask);
-	      }
-	    break;
+              default:
+                RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+                put_byte (ESCAPE, subtask);
+                put_byte ('C', subtask);
+                if (input_char == EOF)
+                  SUBTASK_RETURN (subtask);
+              }
+            break;
 
-	  case 'H':
-	    input_char = get_byte (subtask);
-	    switch (input_char)
-	      {
-	      case 'e': input_char = 137; break;
-	      case 'i': input_char = 139; break;
-	      case 'u': input_char = 129; break;
+          case 'H':
+            input_char = get_byte (subtask);
+            switch (input_char)
+              {
+              case 'e': input_char = 137; break;
+              case 'i': input_char = 139; break;
+              case 'u': input_char = 129; break;
 
-	      default:
-		RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-		put_byte (ESCAPE, subtask);
-		put_byte ('H', subtask);
-		if (input_char == EOF)
-		  SUBTASK_RETURN (subtask);
-	      }
-	    break;
+              default:
+                RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+                put_byte (ESCAPE, subtask);
+                put_byte ('H', subtask);
+                if (input_char == EOF)
+                  SUBTASK_RETURN (subtask);
+              }
+            break;
 
-	  case 'K':
-	    input_char = get_byte (subtask);
-	    switch (input_char)
-	      {
-	      case 'c': input_char = 135; break;
-	      case 'C': input_char = 128; break;
+          case 'K':
+            input_char = get_byte (subtask);
+            switch (input_char)
+              {
+              case 'c': input_char = 135; break;
+              case 'C': input_char = 128; break;
 
-	      default:
-		RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-		put_byte (ESCAPE, subtask);
-		put_byte ('K', subtask);
-		if (input_char == EOF)
-		  SUBTASK_RETURN (subtask);
-	      }
-	    break;
+              default:
+                RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+                put_byte (ESCAPE, subtask);
+                put_byte ('K', subtask);
+                if (input_char == EOF)
+                  SUBTASK_RETURN (subtask);
+              }
+            break;
 
-	  default:
-	    RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-	    put_byte (ESCAPE, subtask);
-	    if (input_char == EOF)
-	      SUBTASK_RETURN (subtask);
-	  }
-	FALLTHROUGH;
+          default:
+            RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+            put_byte (ESCAPE, subtask);
+            if (input_char == EOF)
+              SUBTASK_RETURN (subtask);
+          }
+        FALLTHROUGH;
 
       default:
-	put_byte (input_char, subtask);
-	input_char = get_byte (subtask);
+        put_byte (input_char, subtask);
+        input_char = get_byte (subtask);
       }
 }
 
@@ -222,11 +222,11 @@ module_iconqnx (RECODE_OUTER outer)
 {
   return
     declare_single (outer, "IBM-PC", "Icon-QNX",
-		    outer->quality_variable_to_variable,
-		    NULL, transform_ibmpc_iconqnx)
+                    outer->quality_variable_to_variable,
+                    NULL, transform_ibmpc_iconqnx)
     && declare_single (outer, "Icon-QNX", "IBM-PC",
-		       outer->quality_variable_to_variable,
-		       NULL, transform_iconqnx_ibmpc)
+                       outer->quality_variable_to_variable,
+                       NULL, transform_iconqnx_ibmpc)
     && declare_alias (outer, "QNX", "Icon-QNX");
 }
 

--- a/src/iconv.c
+++ b/src/iconv.c
@@ -113,23 +113,23 @@ wrapped_transform (iconv_t conversion, RECODE_SUBTASK subtask)
 
       drain_first = false;
       if (saved_errno != 0 && saved_errno != E2BIG)
-	{
-	  if (saved_errno == EILSEQ)
-	    {
-	      /* Check whether the input was really just untranslatable.  */
+        {
+          if (saved_errno == EILSEQ)
+            {
+              /* Check whether the input was really just untranslatable.  */
               enum recode_error recode_error = RECODE_INVALID_INPUT;
-	      RECODE_CONST_STEP step = subtask->step;
-	      iconv_t check_conversion = iconv_open (step->before->iconv_name,
-						     step->before->iconv_name);
+              RECODE_CONST_STEP step = subtask->step;
+              iconv_t check_conversion = iconv_open (step->before->iconv_name,
+                                                     step->before->iconv_name);
 
-	      /* On error, give up and assume input is invalid.  */
-	      if (input_left > 0 && check_conversion != (iconv_t) -1)
-		{
+              /* On error, give up and assume input is invalid.  */
+              if (input_left > 0 && check_conversion != (iconv_t) -1)
+                {
                   /* Assume iconv does not modify its input.  */
-		  char *check_input = input;
-		  size_t check_input_left = input_left;
+                  char *check_input = input;
+                  size_t check_input_left = input_left;
                   size_t check_output_left = input_left;
-		  char *check_output_buffer, *check_output;
+                  char *check_output_buffer, *check_output;
                   RECODE_OUTER outer = subtask->task->request->outer;
 
                   if ((check_output = ALLOC (check_output_buffer, input_left, char)) != NULL)
@@ -145,24 +145,24 @@ wrapped_transform (iconv_t conversion, RECODE_SUBTASK subtask)
                     }
 
                   iconv_close (check_conversion);
-		}
+                }
 
-	      /* Invalid or untranslatable input.  */
-	      RETURN_IF_NOGO (recode_error, subtask);
-	    }
-	  else if (saved_errno == EINVAL)
-	    {
-	      if (input + input_left < input_buffer + BUFFER_SIZE
-		  && input_char == EOF)
-		/* Incomplete multibyte sequence at end of input.  */
-		RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-	    }
-	  else
-	    {
-	      recode_perror (subtask->task->request->outer, "iconv ()");
-	      RETURN_IF_NOGO (RECODE_SYSTEM_ERROR, subtask);
-	    }
-	}
+              /* Invalid or untranslatable input.  */
+              RETURN_IF_NOGO (recode_error, subtask);
+            }
+          else if (saved_errno == EINVAL)
+            {
+              if (input + input_left < input_buffer + BUFFER_SIZE
+                  && input_char == EOF)
+                /* Incomplete multibyte sequence at end of input.  */
+                RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+            }
+          else
+            {
+              recode_perror (subtask->task->request->outer, "iconv ()");
+              RETURN_IF_NOGO (RECODE_SYSTEM_ERROR, subtask);
+            }
+        }
 
       /* Move back any unprocessed part of the input buffer.  */
       for (cursor = input_buffer; input_left != 0; input_left--)
@@ -238,39 +238,39 @@ module_iconv (RECODE_OUTER outer)
       const char *charset_name = *cursor;
 
       /* Scan aliases for some charset which would already be known.  If any,
-	 use its official name as a charset.  Else, use the first alias.  */
+         use its official name as a charset.  Else, use the first alias.  */
 
       while (*cursor)
-	{
+        {
           RECODE_ALIAS alias
             = find_alias (outer, *cursor, ALIAS_FIND_AS_CHARSET);
 
-	  if (alias)
-	    {
-	      charset_name = alias->symbol->name;
-	      break;
-	    }
-	  cursor++;
-	}
+          if (alias)
+            {
+              charset_name = alias->symbol->name;
+              break;
+            }
+          cursor++;
+        }
 
       if (!declare_iconv (outer, charset_name, *aliases))
-	return false;
+        return false;
 
       /* Declare all aliases, given they bring something we do not already
-	 know.  Even then, we still declare too many useless aliases, as the
-	 disambiguating tables are not recomputed as we go.  FIXME!  */
+         know.  Even then, we still declare too many useless aliases, as the
+         disambiguating tables are not recomputed as we go.  FIXME!  */
 
       for (cursor = aliases; *cursor; cursor++)
-	{
-	  RECODE_ALIAS alias
-	    = find_alias (outer, *cursor, ALIAS_FIND_AS_CHARSET);
+        {
+          RECODE_ALIAS alias
+            = find_alias (outer, *cursor, ALIAS_FIND_AS_CHARSET);
 
-	  /* If there is a charset contradiction, call declare_alias
-	     nevertheless, as the error processing will occur there.  */
-	  if (!alias || alias->symbol->name != charset_name)
-	    if (!declare_alias (outer, *cursor, charset_name))
-	      return false;
-	}
+          /* If there is a charset contradiction, call declare_alias
+             nevertheless, as the error processing will occur there.  */
+          if (!alias || alias->symbol->name != charset_name)
+            if (!declare_alias (outer, *cursor, charset_name))
+              return false;
+        }
     }
 
   return true;

--- a/src/iso5426lat1.l
+++ b/src/iso5426lat1.l
@@ -91,103 +91,103 @@
 
 
 %%
-\173	{ put_byte (123, subtask); }
+\173    { put_byte (123, subtask); }
 \174    { put_byte (124, subtask); }
 \175    { put_byte (125, subtask); }
 \37     { put_byte (36, subtask); }
-\266	{ put_byte (158, subtask); } 
-\241	{ put_byte (161, subtask); }
-\243	{ put_byte (163, subtask); }
-\244	{ put_byte (36, subtask);  }
-\247	{ put_byte (167, subtask); } 
+\266    { put_byte (158, subtask); } 
+\241    { put_byte (161, subtask); }
+\243    { put_byte (163, subtask); }
+\244    { put_byte (36, subtask);  }
+\247    { put_byte (167, subtask); } 
 
 \210    { put_byte (172, subtask); }
 \211    { put_byte (172, subtask); }
 
-\253	{ put_byte (171, subtask); } 
-\273	{ put_byte (187, subtask); }
-\277	{ put_byte (191, subtask); } 
+\253    { put_byte (171, subtask); } 
+\273    { put_byte (187, subtask); }
+\277    { put_byte (191, subtask); } 
 
-\341	{ put_byte (198, subtask); }
-\342	{ put_byte (208, subtask); }
+\341    { put_byte (198, subtask); }
+\342    { put_byte (208, subtask); }
 
 \350    { put_byte (76, subtask); }
-\351	{ put_byte (216, subtask); }
-\354	{ put_byte (254, subtask); }
-\361	{ put_byte (230, subtask); }
-\362	{ put_byte (100, subtask); }
-\363	{ put_byte (240, subtask); }
-\365	{ put_byte (134, subtask); }
-\370	{ put_byte (108, subtask); }
-\371	{ put_byte (248, subtask); }
-\373	{ put_byte (223, subtask); }
-\374	{ put_byte (222, subtask); } 
+\351    { put_byte (216, subtask); }
+\354    { put_byte (254, subtask); }
+\361    { put_byte (230, subtask); }
+\362    { put_byte (100, subtask); }
+\363    { put_byte (240, subtask); }
+\365    { put_byte (134, subtask); }
+\370    { put_byte (108, subtask); }
+\371    { put_byte (248, subtask); }
+\373    { put_byte (223, subtask); }
+\374    { put_byte (222, subtask); } 
 
-\301a	{ put_byte (224, subtask); } 
-\301e	{ put_byte (232, subtask); } 
-\301i	{ put_byte (236, subtask); } 
-\301o	{ put_byte (242, subtask); } 
-\301u	{ put_byte (249, subtask); } 
+\301a   { put_byte (224, subtask); } 
+\301e   { put_byte (232, subtask); } 
+\301i   { put_byte (236, subtask); } 
+\301o   { put_byte (242, subtask); } 
+\301u   { put_byte (249, subtask); } 
 
-\301A	{ put_byte (192, subtask); } 
-\301E	{ put_byte (200, subtask); } 
-\301I	{ put_byte (204, subtask); } 
-\301O	{ put_byte (210, subtask); } 
-\301U	{ put_byte (217, subtask); } 
+\301A   { put_byte (192, subtask); } 
+\301E   { put_byte (200, subtask); } 
+\301I   { put_byte (204, subtask); } 
+\301O   { put_byte (210, subtask); } 
+\301U   { put_byte (217, subtask); } 
 
-\302a	{ put_byte (225, subtask); } 
-\302e	{ put_byte (233, subtask); } 
-\302i	{ put_byte (237, subtask); } 
-\302o	{ put_byte (243, subtask); } 
-\302u	{ put_byte (250, subtask); } 
-\302y	{ put_byte (253, subtask); } 
+\302a   { put_byte (225, subtask); } 
+\302e   { put_byte (233, subtask); } 
+\302i   { put_byte (237, subtask); } 
+\302o   { put_byte (243, subtask); } 
+\302u   { put_byte (250, subtask); } 
+\302y   { put_byte (253, subtask); } 
 
-\302A	{ put_byte (193, subtask); } 
-\302E	{ put_byte (201, subtask); } 
-\302I	{ put_byte (205, subtask); } 
-\302O	{ put_byte (211, subtask); } 
-\302U	{ put_byte (218, subtask); } 
-\302Y	{ put_byte (221, subtask); } 
+\302A   { put_byte (193, subtask); } 
+\302E   { put_byte (201, subtask); } 
+\302I   { put_byte (205, subtask); } 
+\302O   { put_byte (211, subtask); } 
+\302U   { put_byte (218, subtask); } 
+\302Y   { put_byte (221, subtask); } 
 
-\303a	{ put_byte (226, subtask); } 
-\303e	{ put_byte (234, subtask); } 
-\303i	{ put_byte (238, subtask); } 
-\303o	{ put_byte (244, subtask); } 
-\303u	{ put_byte (251, subtask); } 
+\303a   { put_byte (226, subtask); } 
+\303e   { put_byte (234, subtask); } 
+\303i   { put_byte (238, subtask); } 
+\303o   { put_byte (244, subtask); } 
+\303u   { put_byte (251, subtask); } 
 
-\303A	{ put_byte (194, subtask); } 
-\303E	{ put_byte (202, subtask); } 
-\303I	{ put_byte (206, subtask); } 
-\303O	{ put_byte (212, subtask); } 
-\303U	{ put_byte (219, subtask); } 
+\303A   { put_byte (194, subtask); } 
+\303E   { put_byte (202, subtask); } 
+\303I   { put_byte (206, subtask); } 
+\303O   { put_byte (212, subtask); } 
+\303U   { put_byte (219, subtask); } 
 
-\304a	{ put_byte (227, subtask); } 
-\304o	{ put_byte (245, subtask); } 
-\304n	{ put_byte (241, subtask); } 
+\304a   { put_byte (227, subtask); } 
+\304o   { put_byte (245, subtask); } 
+\304n   { put_byte (241, subtask); } 
 
-\304A	{ put_byte (195, subtask); } 
-\304O	{ put_byte (213, subtask); } 
-\304N	{ put_byte (209, subtask); } 
+\304A   { put_byte (195, subtask); } 
+\304O   { put_byte (213, subtask); } 
+\304N   { put_byte (209, subtask); } 
 
-\310e	{ put_byte (235, subtask); } 
-\310i	{ put_byte (239, subtask); } 
-\310y	{ put_byte (255, subtask); } 
+\310e   { put_byte (235, subtask); } 
+\310i   { put_byte (239, subtask); } 
+\310y   { put_byte (255, subtask); } 
 
-\310E	{ put_byte (203, subtask); } 
-\310I	{ put_byte (207, subtask); } 
+\310E   { put_byte (203, subtask); } 
+\310I   { put_byte (207, subtask); } 
 
-\312a	{ put_byte (229, subtask); } 
-\312A	{ put_byte (197, subtask); } 
+\312a   { put_byte (229, subtask); } 
+\312A   { put_byte (197, subtask); } 
 
-\320c	{ put_byte (231, subtask); } 
-\320C	{ put_byte (199, subtask); } 
+\320c   { put_byte (231, subtask); } 
+\320C   { put_byte (199, subtask); } 
 
-\311a	{ put_byte (228, subtask); } 
-\311o	{ put_byte (246, subtask); } 
-\311u	{ put_byte (252, subtask); } 
-\311A	{ put_byte (196, subtask); } 
-\311O	{ put_byte (214, subtask); } 
-\311U	{ put_byte (220, subtask); }   
+\311a   { put_byte (228, subtask); } 
+\311o   { put_byte (246, subtask); } 
+\311u   { put_byte (252, subtask); } 
+\311A   { put_byte (196, subtask); } 
+\311O   { put_byte (214, subtask); } 
+\311U   { put_byte (220, subtask); }   
 %%
 
 bool

--- a/src/java.c
+++ b/src/java.c
@@ -105,11 +105,11 @@ module_java (RECODE_OUTER outer)
 {
   return
     declare_single (outer, "UTF-16", "Java",
-		       outer->quality_ucs2_to_variable,
-		       NULL, transform_utf16_java)
+                       outer->quality_ucs2_to_variable,
+                       NULL, transform_utf16_java)
     && declare_single (outer, "Java", "UTF-16",
-		       outer->quality_variable_to_ucs2,
-		       NULL, transform_java_utf16);
+                       outer->quality_variable_to_ucs2,
+                       NULL, transform_java_utf16);
 }
 
 void

--- a/src/lat1ansel.c
+++ b/src/lat1ansel.c
@@ -5,7 +5,7 @@
  *
  * Read the file ansellat1.l for more information about Z39.47-1993.
  *
- * 	$Id: lat1ansel.c,v 1.1 1998/02/19 15:51:31 wolfram Exp $
+ *      $Id: lat1ansel.c,v 1.1 1998/02/19 15:51:31 wolfram Exp $
  *
  */
 
@@ -35,8 +35,8 @@
 
 struct translation
   {
-    int code;			/* code being translated */
-    const char *string;		/* translation string */
+    int code;                   /* code being translated */
+    const char *string;         /* translation string */
   };
 
 static struct translation diacritic_translations [] =
@@ -47,9 +47,9 @@ static struct translation diacritic_translations [] =
 
 static bool
 init_latin1_ansel (RECODE_STEP step,
-		   const struct recode_request *request,
-		   RECODE_CONST_OPTION_LIST before_options _GL_UNUSED,
-		   RECODE_CONST_OPTION_LIST after_options _GL_UNUSED)
+                   const struct recode_request *request,
+                   RECODE_CONST_OPTION_LIST before_options _GL_UNUSED,
+                   RECODE_CONST_OPTION_LIST after_options _GL_UNUSED)
 {
   RECODE_OUTER outer = request->outer;
   

--- a/src/lat1asci.c
+++ b/src/lat1asci.c
@@ -23,142 +23,142 @@
 
 static const char *const translation_table[128] =
   {
-    NULL,			/* 128 */
-    NULL,			/* 129 */
-    NULL,			/* 130 */
-    NULL,			/* 131 */
-    NULL,			/* 132 */
-    NULL,			/* 133 */
-    NULL,			/* 134 */
-    NULL,			/* 135 */
-    NULL,			/* 136 */
-    NULL,			/* 137 */
-    NULL,			/* 138 */
-    NULL,			/* 139 */
-    NULL,			/* 140 */
-    NULL,			/* 141 */
-    NULL,			/* 142 */
-    NULL,			/* 143 */
-    NULL,			/* 144 */
-    NULL,			/* 145 */
-    NULL,			/* 146 */
-    NULL,			/* 147 */
-    NULL,			/* 148 */
-    NULL,			/* 149 */
-    NULL,			/* 150 */
-    NULL,			/* 151 */
-    NULL,			/* 152 */
-    NULL,			/* 153 */
-    NULL,			/* 154 */
-    NULL,			/* 155 */
-    NULL,			/* 156 */
-    NULL,			/* 157 */
-    NULL,			/* 158 */
-    NULL,			/* 159 */
+    NULL,                       /* 128 */
+    NULL,                       /* 129 */
+    NULL,                       /* 130 */
+    NULL,                       /* 131 */
+    NULL,                       /* 132 */
+    NULL,                       /* 133 */
+    NULL,                       /* 134 */
+    NULL,                       /* 135 */
+    NULL,                       /* 136 */
+    NULL,                       /* 137 */
+    NULL,                       /* 138 */
+    NULL,                       /* 139 */
+    NULL,                       /* 140 */
+    NULL,                       /* 141 */
+    NULL,                       /* 142 */
+    NULL,                       /* 143 */
+    NULL,                       /* 144 */
+    NULL,                       /* 145 */
+    NULL,                       /* 146 */
+    NULL,                       /* 147 */
+    NULL,                       /* 148 */
+    NULL,                       /* 149 */
+    NULL,                       /* 150 */
+    NULL,                       /* 151 */
+    NULL,                       /* 152 */
+    NULL,                       /* 153 */
+    NULL,                       /* 154 */
+    NULL,                       /* 155 */
+    NULL,                       /* 156 */
+    NULL,                       /* 157 */
+    NULL,                       /* 158 */
+    NULL,                       /* 159 */
 
-    " ",			/* 160 no-break space */
-    NULL,			/* 161 inverted exclamation mark */
-    NULL,			/* 162 cent sign */
-    NULL,			/* 163 pound sign */
-    NULL,			/* 164 currency sign */
-    NULL,			/* 165 yen sign */
-    NULL,			/* 166 broken bar */
-    NULL,			/* 167 paragraph sign, section sign */
-    NULL,			/* 168 diaeresis */
-    NULL,			/* 169 copyright sign */
-    NULL,			/* 170 feminine ordinal indicator */
-    "<\b\"",			/* 171 left angle quotation mark */
-    NULL,			/* 172 not sign */
-    NULL,			/* 173 soft hyphen */
-    NULL,			/* 174 registered trade mark sign */
-    NULL,			/* 175 macron */
-    NULL,			/* 176 degree sign */
-    NULL,			/* 177 plus-minus sign */
-    NULL,			/* 178 superscript two */
-    NULL,			/* 179 superscript three */
-    NULL,			/* 180 acute accent */
-    NULL,			/* 181 small greek mu, micro sign */
-    NULL,			/* 182 pilcrow sign */
-    NULL,			/* 183 middle dot */
-    NULL,			/* 184 cedilla */
-    NULL,			/* 185 superscript one */
-    NULL,			/* 186 masculine ordinal indicator */
-    ">\b\"",			/* 187 right angle quotation mark */
-    NULL,			/* 188 vulgar fraction one quarter */
-    NULL,			/* 189 vulgar fraction one half */
-    NULL,			/* 190 vulgar fraction three quarters */
-    NULL,			/* 191 inverted question mark */
-    "`\bA",			/* 192 capital A with grave accent */
-    "'\bA",			/* 193 capital A with acute accent */
-    "^\bA",			/* 194 capital A with circumflex accent */
-    "~\bA",			/* 195 capital A with tilde */
-    "\"\bA",			/* 196 capital A diaeresis */
-    NULL,			/* 197 capital A with ring above */
-    NULL,			/* 198 capital diphthong A with E */
-    ",\bC",			/* 199 capital C with cedilla */
-    "`\bE",			/* 200 capital E with grave accent */
-    "'\bE",			/* 201 capital E with acute accent */
-    "^\bE",			/* 202 capital E with circumflex accent */
-    "\"\bE",			/* 203 capital E with diaeresis */
-    "`\bI",			/* 204 capital I with grave accent */
-    "'\bI",			/* 205 capital I with acute accent */
-    "^\bI",			/* 206 capital I with circumflex accent */
-    "\"\bI",			/* 207 capital I with diaeresis */
-    NULL,			/* 208 capital icelandic ETH */
-    "~\bN",			/* 209 capital N with tilde */
-    "`\bO",			/* 210 capital O with grave accent */
-    "'\bO",			/* 211 capital O with acute accent */
-    "^\bO",			/* 212 capital O with circumflex accent */
-    "~\bO",			/* 213 capital O with tilde */
-    "\"\bO",			/* 214 capital O with diaeresis */
-    NULL,			/* 215 multiplication sign */
-    "/\bO",			/* 216 capital O with oblique stroke */
-    "`\bU",			/* 217 capital U with grave accent */
-    "'\bU",			/* 218 capital U with acute accent */
-    "^\bU",			/* 219 capital U with circumflex accent */
-    "\"\bU",			/* 220 capital U with diaeresis */
-    "'\bY",			/* 221 capital Y with acute accent */
-    NULL,			/* 222 capital icelandic THORN */
-    "\"\bs",			/* 223 small german sharp s */
-    "`\ba",			/* 224 small a with grave accent */
-    "'\ba",			/* 225 small a with acute accent */
-    "^\ba",			/* 226 small a with circumflex accent */
-    "~\ba",			/* 227 small a with tilde */
-    "\"\ba",			/* 228 small a with diaeresis */
-    NULL,			/* 229 small a with ring above */
-    NULL,			/* 230 small diphthong a with e */
-    ",\bc",			/* 231 small c with cedilla */
-    "`\be",			/* 232 small e with grave accent */
-    "'\be",			/* 233 small e with acute accent */
-    "^\be",			/* 234 small e with circumflex accent */
-    "\"\be",			/* 235 small e with diaeresis */
-    "`\bi",			/* 236 small i with grave accent */
-    "'\bi",			/* 237 small i with acute accent */
-    "^\bi",			/* 238 small i with circumflex accent */
-    "\"\bi",			/* 239 small i with diaeresis */
-    NULL,			/* 240 small icelandic eth */
-    "~\bn",			/* 241 small n with tilde */
-    "`\bo",			/* 242 small o with grave accent */
-    "'\bo",			/* 243 small o with acute accent */
-    "^\bo",			/* 244 small o with circumflex accent */
-    "~\bo",			/* 245 small o with tilde */
-    "\"\bo",			/* 246 small o with diaeresis */
-    NULL,			/* 247 division sign */
-    "/\bo",			/* 248 small o with oblique stroke */
-    "`\bu",			/* 249 small u with grave accent */
-    "'\bu",			/* 250 small u with acute accent */
-    "^\bu",			/* 251 small u with circumflex accent */
-    "\"\bu",			/* 252 small u with diaeresis */
-    "'\by",			/* 253 small y with acute accent */
-    NULL,			/* 254 small icelandic thorn */
-    "\"\by",			/* 255 small y with diaeresis */
+    " ",                        /* 160 no-break space */
+    NULL,                       /* 161 inverted exclamation mark */
+    NULL,                       /* 162 cent sign */
+    NULL,                       /* 163 pound sign */
+    NULL,                       /* 164 currency sign */
+    NULL,                       /* 165 yen sign */
+    NULL,                       /* 166 broken bar */
+    NULL,                       /* 167 paragraph sign, section sign */
+    NULL,                       /* 168 diaeresis */
+    NULL,                       /* 169 copyright sign */
+    NULL,                       /* 170 feminine ordinal indicator */
+    "<\b\"",                    /* 171 left angle quotation mark */
+    NULL,                       /* 172 not sign */
+    NULL,                       /* 173 soft hyphen */
+    NULL,                       /* 174 registered trade mark sign */
+    NULL,                       /* 175 macron */
+    NULL,                       /* 176 degree sign */
+    NULL,                       /* 177 plus-minus sign */
+    NULL,                       /* 178 superscript two */
+    NULL,                       /* 179 superscript three */
+    NULL,                       /* 180 acute accent */
+    NULL,                       /* 181 small greek mu, micro sign */
+    NULL,                       /* 182 pilcrow sign */
+    NULL,                       /* 183 middle dot */
+    NULL,                       /* 184 cedilla */
+    NULL,                       /* 185 superscript one */
+    NULL,                       /* 186 masculine ordinal indicator */
+    ">\b\"",                    /* 187 right angle quotation mark */
+    NULL,                       /* 188 vulgar fraction one quarter */
+    NULL,                       /* 189 vulgar fraction one half */
+    NULL,                       /* 190 vulgar fraction three quarters */
+    NULL,                       /* 191 inverted question mark */
+    "`\bA",                     /* 192 capital A with grave accent */
+    "'\bA",                     /* 193 capital A with acute accent */
+    "^\bA",                     /* 194 capital A with circumflex accent */
+    "~\bA",                     /* 195 capital A with tilde */
+    "\"\bA",                    /* 196 capital A diaeresis */
+    NULL,                       /* 197 capital A with ring above */
+    NULL,                       /* 198 capital diphthong A with E */
+    ",\bC",                     /* 199 capital C with cedilla */
+    "`\bE",                     /* 200 capital E with grave accent */
+    "'\bE",                     /* 201 capital E with acute accent */
+    "^\bE",                     /* 202 capital E with circumflex accent */
+    "\"\bE",                    /* 203 capital E with diaeresis */
+    "`\bI",                     /* 204 capital I with grave accent */
+    "'\bI",                     /* 205 capital I with acute accent */
+    "^\bI",                     /* 206 capital I with circumflex accent */
+    "\"\bI",                    /* 207 capital I with diaeresis */
+    NULL,                       /* 208 capital icelandic ETH */
+    "~\bN",                     /* 209 capital N with tilde */
+    "`\bO",                     /* 210 capital O with grave accent */
+    "'\bO",                     /* 211 capital O with acute accent */
+    "^\bO",                     /* 212 capital O with circumflex accent */
+    "~\bO",                     /* 213 capital O with tilde */
+    "\"\bO",                    /* 214 capital O with diaeresis */
+    NULL,                       /* 215 multiplication sign */
+    "/\bO",                     /* 216 capital O with oblique stroke */
+    "`\bU",                     /* 217 capital U with grave accent */
+    "'\bU",                     /* 218 capital U with acute accent */
+    "^\bU",                     /* 219 capital U with circumflex accent */
+    "\"\bU",                    /* 220 capital U with diaeresis */
+    "'\bY",                     /* 221 capital Y with acute accent */
+    NULL,                       /* 222 capital icelandic THORN */
+    "\"\bs",                    /* 223 small german sharp s */
+    "`\ba",                     /* 224 small a with grave accent */
+    "'\ba",                     /* 225 small a with acute accent */
+    "^\ba",                     /* 226 small a with circumflex accent */
+    "~\ba",                     /* 227 small a with tilde */
+    "\"\ba",                    /* 228 small a with diaeresis */
+    NULL,                       /* 229 small a with ring above */
+    NULL,                       /* 230 small diphthong a with e */
+    ",\bc",                     /* 231 small c with cedilla */
+    "`\be",                     /* 232 small e with grave accent */
+    "'\be",                     /* 233 small e with acute accent */
+    "^\be",                     /* 234 small e with circumflex accent */
+    "\"\be",                    /* 235 small e with diaeresis */
+    "`\bi",                     /* 236 small i with grave accent */
+    "'\bi",                     /* 237 small i with acute accent */
+    "^\bi",                     /* 238 small i with circumflex accent */
+    "\"\bi",                    /* 239 small i with diaeresis */
+    NULL,                       /* 240 small icelandic eth */
+    "~\bn",                     /* 241 small n with tilde */
+    "`\bo",                     /* 242 small o with grave accent */
+    "'\bo",                     /* 243 small o with acute accent */
+    "^\bo",                     /* 244 small o with circumflex accent */
+    "~\bo",                     /* 245 small o with tilde */
+    "\"\bo",                    /* 246 small o with diaeresis */
+    NULL,                       /* 247 division sign */
+    "/\bo",                     /* 248 small o with oblique stroke */
+    "`\bu",                     /* 249 small u with grave accent */
+    "'\bu",                     /* 250 small u with acute accent */
+    "^\bu",                     /* 251 small u with circumflex accent */
+    "\"\bu",                    /* 252 small u with diaeresis */
+    "'\by",                     /* 253 small y with acute accent */
+    NULL,                       /* 254 small icelandic thorn */
+    "\"\by",                    /* 255 small y with diaeresis */
   };
 
 static bool
 init_latin1_ascii (RECODE_STEP step,
-		   RECODE_CONST_REQUEST request,
-		   RECODE_CONST_OPTION_LIST before_options,
-		   RECODE_CONST_OPTION_LIST after_options)
+                   RECODE_CONST_REQUEST request,
+                   RECODE_CONST_OPTION_LIST before_options,
+                   RECODE_CONST_OPTION_LIST after_options)
 {
   RECODE_OUTER outer = request->outer;
 
@@ -192,8 +192,8 @@ bool
 module_latin1_ascii (RECODE_OUTER outer)
 {
   if (!declare_single (outer, "Latin-1", "ASCII-BS",
-		       outer->quality_byte_to_variable,
-		       init_latin1_ascii, transform_byte_to_variable))
+                       outer->quality_byte_to_variable,
+                       init_latin1_ascii, transform_byte_to_variable))
     return false;
 
   return true;

--- a/src/lat1btex.c
+++ b/src/lat1btex.c
@@ -24,70 +24,70 @@
 
 struct translation
   {
-    unsigned code;		/* code being translated */
-    const char *string;		/* translation string */
+    unsigned code;              /* code being translated */
+    const char *string;         /* translation string */
   };
 
 static struct translation const diacritic_translations [] =
   {
-    {192, "{\\`A}"},		/* capital A with grave accent */
-    {193, "{\\'A}"},		/* capital A with acute accent */
-    {194, "{\\^A}"},		/* capital A with circumflex accent */
-    {195, "{\\~A}"},		/* capital A with tilde */
-    {196, "{\\\"A}"},		/* capital A diaeresis */
-    {197, "{\\AA{}}"},		/* capital A with ring above */
-    {198, "{\\AE{}}"},		/* capital diphthong A with E */
-    {199, "{\\c{C}}"},		/* capital C with cedilla */
-    {200, "{\\`E}"},		/* capital E with grave accent */
-    {201, "{\\'E}"},		/* capital E with acute accent */
-    {202, "{\\^E}"},		/* capital E with circumflex accent */
-    {203, "{\\\"E}"},		/* capital E with diaeresis */
-    {204, "{\\`I}"},		/* capital I with grave accent */
-    {205, "{\\'I}"},		/* capital I with acute accent */
-    {206, "{\\^I}"},		/* capital I with circumflex accent */
-    {207, "{\\\"I}"},		/* capital I with diaeresis */
-    {209, "{\\~N}"},		/* capital N with tilde */
-    {210, "{\\`O}"},		/* capital O with grave accent */
-    {211, "{\\'O}"},		/* capital O with acute accent */
-    {212, "{\\^O}"},		/* capital O with circumflex accent */
-    {213, "{\\~O}"},		/* capital O with tilde */
-    {214, "{\\\"O}"},		/* capital O with diaeresis */
-    {216, "{\\O{}}"},		/* capital O with oblique stroke */
-    {217, "{\\`U}"},		/* capital U with grave accent */
-    {218, "{\\'U}"},		/* capital U with acute accent */
-    {219, "{\\^U}"},		/* capital U with circumflex accent */
-    {220, "{\\\"U}"},		/* capital U with diaeresis */
-    {221, "{\\'Y}"},		/* capital Y with acute accent */
-    {223, "{\\ss{}}"},		/* small german sharp s */
-    {224, "{\\`a}"},		/* small a with grave accent */
-    {225, "{\\'a}"},		/* small a with acute accent */
-    {226, "{\\^a}"},		/* small a with circumflex accent */
-    {227, "{\\~a}"},		/* small a with tilde */
-    {228, "{\\\"a}"},		/* small a with diaeresis */
-    {229, "{\\aa{}}"},		/* small a with ring above */
-    {230, "{\\ae{}}"},		/* small diphthong a with e */
-    {231, "{\\c{c}}"},		/* small c with cedilla */
-    {232, "{\\`e}"},		/* small e with grave accent */
-    {233, "{\\'e}"},		/* small e with acute accent */
-    {234, "{\\^e}"},		/* small e with circumflex accent */
-    {235, "{\\\"e}"},		/* small e with diaeresis */
-    {236, "{\\`{\\i}}"},	/* small i with grave accent */
-    {237, "{\\'{\\i}}"},	/* small i with acute accent */
-    {238, "{\\^{\\i}}"},	/* small i with circumflex accent */
-    {239, "{\\\"{\\i}}"},	/* small i with diaeresis */
-    {241, "{\\~n}"},		/* small n with tilde */
-    {242, "{\\`o}"},		/* small o with grave accent */
-    {243, "{\\'o}"},		/* small o with acute accent */
-    {244, "{\\^o}"},		/* small o with circumflex accent */
-    {245, "{\\~o}"},		/* small o with tilde */
-    {246, "{\\\"o}"},		/* small o with diaeresis */
-    {248, "{\\o{}}"},		/* small o with oblique stroke */
-    {249, "{\\`u}"},		/* small u with grave accent */
-    {250, "{\\'u}"},		/* small u with acute accent */
-    {251, "{\\^u}"},		/* small u with circumflex accent */
-    {252, "{\\\"u}"},		/* small u with diaeresis */
-    {253, "{\\'y}"},		/* small y with acute accent */
-    {255, "{\\\"y}"},		/* small y with diaeresis */
+    {192, "{\\`A}"},            /* capital A with grave accent */
+    {193, "{\\'A}"},            /* capital A with acute accent */
+    {194, "{\\^A}"},            /* capital A with circumflex accent */
+    {195, "{\\~A}"},            /* capital A with tilde */
+    {196, "{\\\"A}"},           /* capital A diaeresis */
+    {197, "{\\AA{}}"},          /* capital A with ring above */
+    {198, "{\\AE{}}"},          /* capital diphthong A with E */
+    {199, "{\\c{C}}"},          /* capital C with cedilla */
+    {200, "{\\`E}"},            /* capital E with grave accent */
+    {201, "{\\'E}"},            /* capital E with acute accent */
+    {202, "{\\^E}"},            /* capital E with circumflex accent */
+    {203, "{\\\"E}"},           /* capital E with diaeresis */
+    {204, "{\\`I}"},            /* capital I with grave accent */
+    {205, "{\\'I}"},            /* capital I with acute accent */
+    {206, "{\\^I}"},            /* capital I with circumflex accent */
+    {207, "{\\\"I}"},           /* capital I with diaeresis */
+    {209, "{\\~N}"},            /* capital N with tilde */
+    {210, "{\\`O}"},            /* capital O with grave accent */
+    {211, "{\\'O}"},            /* capital O with acute accent */
+    {212, "{\\^O}"},            /* capital O with circumflex accent */
+    {213, "{\\~O}"},            /* capital O with tilde */
+    {214, "{\\\"O}"},           /* capital O with diaeresis */
+    {216, "{\\O{}}"},           /* capital O with oblique stroke */
+    {217, "{\\`U}"},            /* capital U with grave accent */
+    {218, "{\\'U}"},            /* capital U with acute accent */
+    {219, "{\\^U}"},            /* capital U with circumflex accent */
+    {220, "{\\\"U}"},           /* capital U with diaeresis */
+    {221, "{\\'Y}"},            /* capital Y with acute accent */
+    {223, "{\\ss{}}"},          /* small german sharp s */
+    {224, "{\\`a}"},            /* small a with grave accent */
+    {225, "{\\'a}"},            /* small a with acute accent */
+    {226, "{\\^a}"},            /* small a with circumflex accent */
+    {227, "{\\~a}"},            /* small a with tilde */
+    {228, "{\\\"a}"},           /* small a with diaeresis */
+    {229, "{\\aa{}}"},          /* small a with ring above */
+    {230, "{\\ae{}}"},          /* small diphthong a with e */
+    {231, "{\\c{c}}"},          /* small c with cedilla */
+    {232, "{\\`e}"},            /* small e with grave accent */
+    {233, "{\\'e}"},            /* small e with acute accent */
+    {234, "{\\^e}"},            /* small e with circumflex accent */
+    {235, "{\\\"e}"},           /* small e with diaeresis */
+    {236, "{\\`{\\i}}"},        /* small i with grave accent */
+    {237, "{\\'{\\i}}"},        /* small i with acute accent */
+    {238, "{\\^{\\i}}"},        /* small i with circumflex accent */
+    {239, "{\\\"{\\i}}"},       /* small i with diaeresis */
+    {241, "{\\~n}"},            /* small n with tilde */
+    {242, "{\\`o}"},            /* small o with grave accent */
+    {243, "{\\'o}"},            /* small o with acute accent */
+    {244, "{\\^o}"},            /* small o with circumflex accent */
+    {245, "{\\~o}"},            /* small o with tilde */
+    {246, "{\\\"o}"},           /* small o with diaeresis */
+    {248, "{\\o{}}"},           /* small o with oblique stroke */
+    {249, "{\\`u}"},            /* small u with grave accent */
+    {250, "{\\'u}"},            /* small u with acute accent */
+    {251, "{\\^u}"},            /* small u with circumflex accent */
+    {252, "{\\\"u}"},           /* small u with diaeresis */
+    {253, "{\\'y}"},            /* small y with acute accent */
+    {255, "{\\\"y}"},           /* small y with diaeresis */
     {0, NULL}
   };
 
@@ -101,37 +101,37 @@ static struct translation const other_translations [] =
     { 95, "\\_"},
     {123, "\\{"},
     {125, "\\}"},
-    {160, "~"},			/* no-break space */
-    {161, "!`"},		/* inverted exclamation mark */
-    {163, "\\pound{}"},		/* pound sign */
-    {167, "\\S{}"},		/* paragraph sign, section sign */
-    {168, "\\\"{}"},		/* diaeresis */
-    {169, "\\copyright{}"},	/* copyright sign */
-    {171, "``"},		/* left angle quotation mark */
-    {172, "\\neg{}"},		/* not sign */
-    {173, "\\-"},		/* soft hyphen */
+    {160, "~"},                 /* no-break space */
+    {161, "!`"},                /* inverted exclamation mark */
+    {163, "\\pound{}"},         /* pound sign */
+    {167, "\\S{}"},             /* paragraph sign, section sign */
+    {168, "\\\"{}"},            /* diaeresis */
+    {169, "\\copyright{}"},     /* copyright sign */
+    {171, "``"},                /* left angle quotation mark */
+    {172, "\\neg{}"},           /* not sign */
+    {173, "\\-"},               /* soft hyphen */
     {176, "\\mbox{$^\\circ$}"}, /* degree sign */
-    {177, "\\mbox{$\\pm$}"},	/* plus-minus sign */
-    {178, "\\mbox{$^2$}"},	/* superscript two */
-    {179, "\\mbox{$^3$}"},	/* superscript three */
-    {180, "\\'{}"},		/* acute accent */
-    {181, "\\mbox{$\\mu$}"},	/* small greek mu, micro sign */
-    {183, "\\cdotp"},		/* middle dot */
-    {184, "\\,{}"},		/* cedilla */
-    {185, "\\mbox{$^1$}"},	/* superscript one */
-    {187, "''"},		/* right angle quotation mark */
-    {188, "\\frac1/4{}"},	/* vulgar fraction one quarter */
-    {189, "\\frac1/2{}"},	/* vulgar fraction one half */
-    {190, "\\frac3/4{}"},	/* vulgar fraction three quarters */
-    {191, "?`"},		/* inverted question mark */
+    {177, "\\mbox{$\\pm$}"},    /* plus-minus sign */
+    {178, "\\mbox{$^2$}"},      /* superscript two */
+    {179, "\\mbox{$^3$}"},      /* superscript three */
+    {180, "\\'{}"},             /* acute accent */
+    {181, "\\mbox{$\\mu$}"},    /* small greek mu, micro sign */
+    {183, "\\cdotp"},           /* middle dot */
+    {184, "\\,{}"},             /* cedilla */
+    {185, "\\mbox{$^1$}"},      /* superscript one */
+    {187, "''"},                /* right angle quotation mark */
+    {188, "\\frac1/4{}"},       /* vulgar fraction one quarter */
+    {189, "\\frac1/2{}"},       /* vulgar fraction one half */
+    {190, "\\frac3/4{}"},       /* vulgar fraction three quarters */
+    {191, "?`"},                /* inverted question mark */
     {0, NULL}
   };
 
 static bool
 init_latin1_bibtex (RECODE_STEP step,
-		   RECODE_CONST_REQUEST request,
-		   RECODE_CONST_OPTION_LIST before_options,
-		   RECODE_CONST_OPTION_LIST after_options)
+                   RECODE_CONST_REQUEST request,
+                   RECODE_CONST_OPTION_LIST before_options,
+                   RECODE_CONST_OPTION_LIST after_options)
 {
   RECODE_OUTER outer = request->outer;
   char *pool;
@@ -172,8 +172,8 @@ module_latin1_bibtex (RECODE_OUTER outer)
 {
   return
     declare_single (outer, "Latin-1", "BibTeX",
-		    outer->quality_byte_to_variable,
-		    init_latin1_bibtex, transform_byte_to_variable)
+                    outer->quality_byte_to_variable,
+                    init_latin1_bibtex, transform_byte_to_variable)
     && declare_alias (outer, "bibtex", "BibTeX")
     && declare_alias (outer, "btex", "BibTeX");
 }

--- a/src/lat1iso5426.c
+++ b/src/lat1iso5426.c
@@ -33,8 +33,8 @@
 
 struct translation
   {
-    int code;			/* code being translated */
-    const char *string;		/* translation string */
+    int code;                   /* code being translated */
+    const char *string;         /* translation string */
   };
 
 static struct translation diacritic_translations [] =

--- a/src/lat1ltex.c
+++ b/src/lat1ltex.c
@@ -23,70 +23,70 @@
 
 struct translation
   {
-    unsigned code;		/* code being translated */
-    const char *string;		/* translation string */
+    unsigned code;              /* code being translated */
+    const char *string;         /* translation string */
   };
 
 static struct translation const diacritic_translations [] =
   {
-    {192, "\\`A"},		/* capital A with grave accent */
-    {193, "\\'A"},		/* capital A with acute accent */
-    {194, "\\^A"},		/* capital A with circumflex accent */
-    {195, "\\~A"},		/* capital A with tilde */
-    {196, "\\\"A"},		/* capital A diaeresis */
-    {197, "\\AA{}"},		/* capital A with ring above */
-    {198, "\\AE{}"},		/* capital diphthong A with E */
-    {199, "\\c{C}"},		/* capital C with cedilla */
-    {200, "\\`E"},		/* capital E with grave accent */
-    {201, "\\'E"},		/* capital E with acute accent */
-    {202, "\\^E"},		/* capital E with circumflex accent */
-    {203, "\\\"E"},		/* capital E with diaeresis */
-    {204, "\\`I"},		/* capital I with grave accent */
-    {205, "\\'I"},		/* capital I with acute accent */
-    {206, "\\^I"},		/* capital I with circumflex accent */
-    {207, "\\\"I"},		/* capital I with diaeresis */
-    {209, "\\~N"},		/* capital N with tilde */
-    {210, "\\`O"},		/* capital O with grave accent */
-    {211, "\\'O"},		/* capital O with acute accent */
-    {212, "\\^O"},		/* capital O with circumflex accent */
-    {213, "\\~O"},		/* capital O with tilde */
-    {214, "\\\"O"},		/* capital O with diaeresis */
-    {216, "\\O{}"},		/* capital O with oblique stroke */
-    {217, "\\`U"},		/* capital U with grave accent */
-    {218, "\\'U"},		/* capital U with acute accent */
-    {219, "\\^U"},		/* capital U with circumflex accent */
-    {220, "\\\"U"},		/* capital U with diaeresis */
-    {221, "\\'Y"},		/* capital Y with acute accent */
-    {223, "\\ss{}"},		/* small german sharp s */
-    {224, "\\`a"},		/* small a with grave accent */
-    {225, "\\'a"},		/* small a with acute accent */
-    {226, "\\^a"},		/* small a with circumflex accent */
-    {227, "\\~a"},		/* small a with tilde */
-    {228, "\\\"a"},		/* small a with diaeresis */
-    {229, "\\aa{}"},		/* small a with ring above */
-    {230, "\\ae{}"},		/* small diphthong a with e */
-    {231, "\\c{c}"},		/* small c with cedilla */
-    {232, "\\`e"},		/* small e with grave accent */
-    {233, "\\'e"},		/* small e with acute accent */
-    {234, "\\^e"},		/* small e with circumflex accent */
-    {235, "\\\"e"},		/* small e with diaeresis */
-    {236, "\\`{\\i}"},		/* small i with grave accent */
-    {237, "\\'{\\i}"},		/* small i with acute accent */
-    {238, "\\^{\\i}"},		/* small i with circumflex accent */
-    {239, "\\\"{\\i}"},		/* small i with diaeresis */
-    {241, "\\~n"},		/* small n with tilde */
-    {242, "\\`o"},		/* small o with grave accent */
-    {243, "\\'o"},		/* small o with acute accent */
-    {244, "\\^o"},		/* small o with circumflex accent */
-    {245, "\\~o"},		/* small o with tilde */
-    {246, "\\\"o"},		/* small o with diaeresis */
-    {248, "\\o{}"},		/* small o with oblique stroke */
-    {249, "\\`u"},		/* small u with grave accent */
-    {250, "\\'u"},		/* small u with acute accent */
-    {251, "\\^u"},		/* small u with circumflex accent */
-    {252, "\\\"u"},		/* small u with diaeresis */
-    {253, "\\'y"},		/* small y with acute accent */
-    {255, "\\\"y"},		/* small y with diaeresis */
+    {192, "\\`A"},              /* capital A with grave accent */
+    {193, "\\'A"},              /* capital A with acute accent */
+    {194, "\\^A"},              /* capital A with circumflex accent */
+    {195, "\\~A"},              /* capital A with tilde */
+    {196, "\\\"A"},             /* capital A diaeresis */
+    {197, "\\AA{}"},            /* capital A with ring above */
+    {198, "\\AE{}"},            /* capital diphthong A with E */
+    {199, "\\c{C}"},            /* capital C with cedilla */
+    {200, "\\`E"},              /* capital E with grave accent */
+    {201, "\\'E"},              /* capital E with acute accent */
+    {202, "\\^E"},              /* capital E with circumflex accent */
+    {203, "\\\"E"},             /* capital E with diaeresis */
+    {204, "\\`I"},              /* capital I with grave accent */
+    {205, "\\'I"},              /* capital I with acute accent */
+    {206, "\\^I"},              /* capital I with circumflex accent */
+    {207, "\\\"I"},             /* capital I with diaeresis */
+    {209, "\\~N"},              /* capital N with tilde */
+    {210, "\\`O"},              /* capital O with grave accent */
+    {211, "\\'O"},              /* capital O with acute accent */
+    {212, "\\^O"},              /* capital O with circumflex accent */
+    {213, "\\~O"},              /* capital O with tilde */
+    {214, "\\\"O"},             /* capital O with diaeresis */
+    {216, "\\O{}"},             /* capital O with oblique stroke */
+    {217, "\\`U"},              /* capital U with grave accent */
+    {218, "\\'U"},              /* capital U with acute accent */
+    {219, "\\^U"},              /* capital U with circumflex accent */
+    {220, "\\\"U"},             /* capital U with diaeresis */
+    {221, "\\'Y"},              /* capital Y with acute accent */
+    {223, "\\ss{}"},            /* small german sharp s */
+    {224, "\\`a"},              /* small a with grave accent */
+    {225, "\\'a"},              /* small a with acute accent */
+    {226, "\\^a"},              /* small a with circumflex accent */
+    {227, "\\~a"},              /* small a with tilde */
+    {228, "\\\"a"},             /* small a with diaeresis */
+    {229, "\\aa{}"},            /* small a with ring above */
+    {230, "\\ae{}"},            /* small diphthong a with e */
+    {231, "\\c{c}"},            /* small c with cedilla */
+    {232, "\\`e"},              /* small e with grave accent */
+    {233, "\\'e"},              /* small e with acute accent */
+    {234, "\\^e"},              /* small e with circumflex accent */
+    {235, "\\\"e"},             /* small e with diaeresis */
+    {236, "\\`{\\i}"},          /* small i with grave accent */
+    {237, "\\'{\\i}"},          /* small i with acute accent */
+    {238, "\\^{\\i}"},          /* small i with circumflex accent */
+    {239, "\\\"{\\i}"},         /* small i with diaeresis */
+    {241, "\\~n"},              /* small n with tilde */
+    {242, "\\`o"},              /* small o with grave accent */
+    {243, "\\'o"},              /* small o with acute accent */
+    {244, "\\^o"},              /* small o with circumflex accent */
+    {245, "\\~o"},              /* small o with tilde */
+    {246, "\\\"o"},             /* small o with diaeresis */
+    {248, "\\o{}"},             /* small o with oblique stroke */
+    {249, "\\`u"},              /* small u with grave accent */
+    {250, "\\'u"},              /* small u with acute accent */
+    {251, "\\^u"},              /* small u with circumflex accent */
+    {252, "\\\"u"},             /* small u with diaeresis */
+    {253, "\\'y"},              /* small y with acute accent */
+    {255, "\\\"y"},             /* small y with diaeresis */
     {0, NULL}
   };
 
@@ -103,37 +103,37 @@ static struct translation const other_translations [] =
     { 95, "\\_"},
     {123, "\\{"},
     {125, "\\}"},
-    {160, "~"},			/* no-break space */
-    {161, "!`"},		/* inverted exclamation mark */
-    {163, "\\pound{}"},		/* pound sign */
-    {167, "\\S{}"},		/* paragraph sign, section sign */
-    {168, "\\\"{}"},		/* diaeresis */
-    {169, "\\copyright{}"},	/* copyright sign */
-    {171, "``"},		/* left angle quotation mark */
-    {172, "\\neg{}"},		/* not sign */
-    {173, "\\-"},		/* soft hyphen */
+    {160, "~"},                 /* no-break space */
+    {161, "!`"},                /* inverted exclamation mark */
+    {163, "\\pound{}"},         /* pound sign */
+    {167, "\\S{}"},             /* paragraph sign, section sign */
+    {168, "\\\"{}"},            /* diaeresis */
+    {169, "\\copyright{}"},     /* copyright sign */
+    {171, "``"},                /* left angle quotation mark */
+    {172, "\\neg{}"},           /* not sign */
+    {173, "\\-"},               /* soft hyphen */
     {176, "\\mbox{$^\\circ$}"}, /* degree sign */
-    {177, "\\mbox{$\\pm$}"},	/* plus-minus sign */
-    {178, "\\mbox{$^2$}"},	/* superscript two */
-    {179, "\\mbox{$^3$}"},	/* superscript three */
-    {180, "\\'{}"},		/* acute accent */
-    {181, "\\mbox{$\\mu$}"},	/* small greek mu, micro sign */
-    {183, "\\cdotp"},		/* middle dot */
-    {184, "\\,{}"},		/* cedilla */
-    {185, "\\mbox{$^1$}"},	/* superscript one */
-    {187, "''"},		/* right angle quotation mark */
-    {188, "\\frac1/4{}"},	/* vulgar fraction one quarter */
-    {189, "\\frac1/2{}"},	/* vulgar fraction one half */
-    {190, "\\frac3/4{}"},	/* vulgar fraction three quarters */
-    {191, "?`"},		/* inverted question mark */
+    {177, "\\mbox{$\\pm$}"},    /* plus-minus sign */
+    {178, "\\mbox{$^2$}"},      /* superscript two */
+    {179, "\\mbox{$^3$}"},      /* superscript three */
+    {180, "\\'{}"},             /* acute accent */
+    {181, "\\mbox{$\\mu$}"},    /* small greek mu, micro sign */
+    {183, "\\cdotp"},           /* middle dot */
+    {184, "\\,{}"},             /* cedilla */
+    {185, "\\mbox{$^1$}"},      /* superscript one */
+    {187, "''"},                /* right angle quotation mark */
+    {188, "\\frac1/4{}"},       /* vulgar fraction one quarter */
+    {189, "\\frac1/2{}"},       /* vulgar fraction one half */
+    {190, "\\frac3/4{}"},       /* vulgar fraction three quarters */
+    {191, "?`"},                /* inverted question mark */
     {0, NULL}
   };
 
 static bool
 init_latin1_latex (RECODE_STEP step,
-		   RECODE_CONST_REQUEST request,
-		   RECODE_CONST_OPTION_LIST before_options,
-		   RECODE_CONST_OPTION_LIST after_options)
+                   RECODE_CONST_REQUEST request,
+                   RECODE_CONST_OPTION_LIST before_options,
+                   RECODE_CONST_OPTION_LIST after_options)
 {
   RECODE_OUTER outer = request->outer;
   char *pool;
@@ -174,8 +174,8 @@ module_latin1_latex (RECODE_OUTER outer)
 {
   return
     declare_single (outer, "Latin-1", "LaTeX",
-		    outer->quality_byte_to_variable,
-		    init_latin1_latex, transform_byte_to_variable)
+                    outer->quality_byte_to_variable,
+                    init_latin1_latex, transform_byte_to_variable)
     && declare_alias (outer, "TeX", "LaTeX")
     && declare_alias (outer, "ltex", "LaTeX");
 }

--- a/src/lat1txte.c
+++ b/src/lat1txte.c
@@ -23,149 +23,149 @@
 
 static const char *const translation_table[128] =
   {
-    NULL,			/* 128 */
-    NULL,			/* 129 */
-    NULL,			/* 130 */
-    NULL,			/* 131 */
-    NULL,			/* 132 */
-    NULL,			/* 133 */
-    NULL,			/* 134 */
-    NULL,			/* 135 */
-    NULL,			/* 136 */
-    NULL,			/* 137 */
-    NULL,			/* 138 */
-    NULL,			/* 139 */
-    NULL,			/* 140 */
-    NULL,			/* 141 */
-    NULL,			/* 142 */
-    NULL,			/* 143 */
-    NULL,			/* 144 */
-    NULL,			/* 145 */
-    NULL,			/* 146 */
-    NULL,			/* 147 */
-    NULL,			/* 148 */
-    NULL,			/* 149 */
-    NULL,			/* 150 */
-    NULL,			/* 151 */
-    NULL,			/* 152 */
-    NULL,			/* 153 */
-    NULL,			/* 154 */
-    NULL,			/* 155 */
-    NULL,			/* 156 */
-    NULL,			/* 157 */
-    NULL,			/* 158 */
-    NULL,			/* 159 */
+    NULL,                       /* 128 */
+    NULL,                       /* 129 */
+    NULL,                       /* 130 */
+    NULL,                       /* 131 */
+    NULL,                       /* 132 */
+    NULL,                       /* 133 */
+    NULL,                       /* 134 */
+    NULL,                       /* 135 */
+    NULL,                       /* 136 */
+    NULL,                       /* 137 */
+    NULL,                       /* 138 */
+    NULL,                       /* 139 */
+    NULL,                       /* 140 */
+    NULL,                       /* 141 */
+    NULL,                       /* 142 */
+    NULL,                       /* 143 */
+    NULL,                       /* 144 */
+    NULL,                       /* 145 */
+    NULL,                       /* 146 */
+    NULL,                       /* 147 */
+    NULL,                       /* 148 */
+    NULL,                       /* 149 */
+    NULL,                       /* 150 */
+    NULL,                       /* 151 */
+    NULL,                       /* 152 */
+    NULL,                       /* 153 */
+    NULL,                       /* 154 */
+    NULL,                       /* 155 */
+    NULL,                       /* 156 */
+    NULL,                       /* 157 */
+    NULL,                       /* 158 */
+    NULL,                       /* 159 */
 
-    " ",			/* 160 no-break space */
-    NULL,			/* 161 inverted exclamation mark */
-    NULL,			/* 162 cent sign */
-    NULL,			/* 163 pound sign */
-    NULL,			/* 164 currency sign */
-    NULL,			/* 165 yen sign */
-    NULL,			/* 166 broken bar */
-    NULL,			/* 167 paragraph sign, section sign */
-    NULL,			/* 168 diaeresis */
-    NULL,			/* 169 copyright sign */
-    NULL,			/* 170 feminine ordinal indicator */
-    "``",			/* 171 left angle quotation mark */
-    NULL,			/* 172 not sign */
-    NULL,			/* 173 soft hyphen */
-    NULL,			/* 174 registered trade mark sign */
-    NULL,			/* 175 macron */
-    NULL,			/* 176 degree sign */
-    NULL,			/* 177 plus-minus sign */
-    NULL,			/* 178 superscript two */
-    NULL,			/* 179 superscript three */
-    NULL,			/* 180 acute accent */
-    NULL,			/* 181 small greek mu, micro sign */
-    NULL,			/* 182 pilcrow sign */
-    NULL,			/* 183 middle dot */
-    NULL,			/* 184 cedilla */
-    NULL,			/* 185 superscript one */
-    NULL,			/* 186 masculine ordinal indicator */
-    "''",			/* 187 right angle quotation mark */
-    NULL,			/* 188 vulgar fraction one quarter */
-    NULL,			/* 189 vulgar fraction one half */
-    NULL,			/* 190 vulgar fraction three quarters */
-    NULL,			/* 191 inverted question mark */
-    "A`",			/* 192 capital A with grave accent */
-    NULL,			/* 193 capital A with acute accent */
-    "A^",			/* 194 capital A with circumflex accent */
-    NULL,			/* 195 capital A with tilde */
-    "A\"",			/* 196 capital A diaeresis */
-    NULL,			/* 197 capital A with ring above */
-    NULL,			/* 198 capital diphthong A with E */
-    "C,",			/* 199 capital C with cedilla */
-    "E`",			/* 200 capital E with grave accent */
-    "E\'",			/* 201 capital E with acute accent */
-    "E^",			/* 202 capital E with circumflex accent */
-    "E\"",			/* 203 capital E with diaeresis */
-    NULL,			/* 204 capital I with grave accent */
-    NULL,			/* 205 capital I with acute accent */
-    "I^",			/* 206 capital I with circumflex accent */
-    "I\"",			/* 207 capital I with diaeresis */
-    NULL,			/* 208 capital icelandic ETH */
-    NULL,			/* 209 capital N with tilde */
-    "O`",			/* 210 capital O with grave accent */
-    NULL,			/* 211 capital O with acute accent */
-    "O^",			/* 212 capital O with circumflex accent */
-    NULL,			/* 213 capital O with tilde */
-    "O\"",			/* 214 capital O with diaeresis */
-    NULL,			/* 215 multiplication sign */
-    NULL,			/* 216 capital O with oblique stroke */
-    "U`",			/* 217 capital U with grave accent */
-    NULL,			/* 218 capital U with acute accent */
-    "U^",			/* 219 capital U with circumflex accent */
-    "U\"",			/* 220 capital U with diaeresis */
-    NULL,			/* 221 capital Y with acute accent */
-    NULL,			/* 222 capital icelandic THORN */
-    NULL,			/* 223 small german sharp s */
-    "a`",			/* 224 small a with grave accent */
-    NULL,			/* 225 small a with acute accent */
-    "a^",			/* 226 small a with circumflex accent */
-    NULL,			/* 227 small a with tilde */
-    "a\"",			/* 228 small a with diaeresis */
-    NULL,			/* 229 small a with ring above */
-    NULL,			/* 230 small diphthong a with e */
-    "c,",			/* 231 small c with cedilla */
-    "e`",			/* 232 small e with grave accent */
-    "e\'",			/* 233 small e with acute accent */
-    "e^",			/* 234 small e with circumflex accent */
-    "e\"",			/* 235 small e with diaeresis */
-    NULL,			/* 236 small i with grave accent */
-    NULL,			/* 237 small i with acute accent */
-    "i^",			/* 238 small i with circumflex accent */
-    "i\"",			/* 239 small i with diaeresis */
-    NULL,			/* 240 small icelandic eth */
-    NULL,			/* 241 small n with tilde */
-    "o`",			/* 242 small o with grave accent */
-    NULL,			/* 243 small o with acute accent */
-    "o^",			/* 244 small o with circumflex accent */
-    NULL,			/* 245 small o with tilde */
-    "o\"",			/* 246 small o with diaeresis */
-    NULL,			/* 247 division sign */
-    NULL,			/* 248 small o with oblique stroke */
-    "u`",			/* 249 small u with grave accent */
-    NULL,			/* 250 small u with acute accent */
-    "u^",			/* 251 small u with circumflex accent */
-    "u\"",			/* 252 small u with diaeresis */
-    NULL,			/* 253 small y with acute accent */
-    NULL,			/* 254 small icelandic thorn */
-    NULL,			/* 255 small y with diaeresis */
+    " ",                        /* 160 no-break space */
+    NULL,                       /* 161 inverted exclamation mark */
+    NULL,                       /* 162 cent sign */
+    NULL,                       /* 163 pound sign */
+    NULL,                       /* 164 currency sign */
+    NULL,                       /* 165 yen sign */
+    NULL,                       /* 166 broken bar */
+    NULL,                       /* 167 paragraph sign, section sign */
+    NULL,                       /* 168 diaeresis */
+    NULL,                       /* 169 copyright sign */
+    NULL,                       /* 170 feminine ordinal indicator */
+    "``",                       /* 171 left angle quotation mark */
+    NULL,                       /* 172 not sign */
+    NULL,                       /* 173 soft hyphen */
+    NULL,                       /* 174 registered trade mark sign */
+    NULL,                       /* 175 macron */
+    NULL,                       /* 176 degree sign */
+    NULL,                       /* 177 plus-minus sign */
+    NULL,                       /* 178 superscript two */
+    NULL,                       /* 179 superscript three */
+    NULL,                       /* 180 acute accent */
+    NULL,                       /* 181 small greek mu, micro sign */
+    NULL,                       /* 182 pilcrow sign */
+    NULL,                       /* 183 middle dot */
+    NULL,                       /* 184 cedilla */
+    NULL,                       /* 185 superscript one */
+    NULL,                       /* 186 masculine ordinal indicator */
+    "''",                       /* 187 right angle quotation mark */
+    NULL,                       /* 188 vulgar fraction one quarter */
+    NULL,                       /* 189 vulgar fraction one half */
+    NULL,                       /* 190 vulgar fraction three quarters */
+    NULL,                       /* 191 inverted question mark */
+    "A`",                       /* 192 capital A with grave accent */
+    NULL,                       /* 193 capital A with acute accent */
+    "A^",                       /* 194 capital A with circumflex accent */
+    NULL,                       /* 195 capital A with tilde */
+    "A\"",                      /* 196 capital A diaeresis */
+    NULL,                       /* 197 capital A with ring above */
+    NULL,                       /* 198 capital diphthong A with E */
+    "C,",                       /* 199 capital C with cedilla */
+    "E`",                       /* 200 capital E with grave accent */
+    "E\'",                      /* 201 capital E with acute accent */
+    "E^",                       /* 202 capital E with circumflex accent */
+    "E\"",                      /* 203 capital E with diaeresis */
+    NULL,                       /* 204 capital I with grave accent */
+    NULL,                       /* 205 capital I with acute accent */
+    "I^",                       /* 206 capital I with circumflex accent */
+    "I\"",                      /* 207 capital I with diaeresis */
+    NULL,                       /* 208 capital icelandic ETH */
+    NULL,                       /* 209 capital N with tilde */
+    "O`",                       /* 210 capital O with grave accent */
+    NULL,                       /* 211 capital O with acute accent */
+    "O^",                       /* 212 capital O with circumflex accent */
+    NULL,                       /* 213 capital O with tilde */
+    "O\"",                      /* 214 capital O with diaeresis */
+    NULL,                       /* 215 multiplication sign */
+    NULL,                       /* 216 capital O with oblique stroke */
+    "U`",                       /* 217 capital U with grave accent */
+    NULL,                       /* 218 capital U with acute accent */
+    "U^",                       /* 219 capital U with circumflex accent */
+    "U\"",                      /* 220 capital U with diaeresis */
+    NULL,                       /* 221 capital Y with acute accent */
+    NULL,                       /* 222 capital icelandic THORN */
+    NULL,                       /* 223 small german sharp s */
+    "a`",                       /* 224 small a with grave accent */
+    NULL,                       /* 225 small a with acute accent */
+    "a^",                       /* 226 small a with circumflex accent */
+    NULL,                       /* 227 small a with tilde */
+    "a\"",                      /* 228 small a with diaeresis */
+    NULL,                       /* 229 small a with ring above */
+    NULL,                       /* 230 small diphthong a with e */
+    "c,",                       /* 231 small c with cedilla */
+    "e`",                       /* 232 small e with grave accent */
+    "e\'",                      /* 233 small e with acute accent */
+    "e^",                       /* 234 small e with circumflex accent */
+    "e\"",                      /* 235 small e with diaeresis */
+    NULL,                       /* 236 small i with grave accent */
+    NULL,                       /* 237 small i with acute accent */
+    "i^",                       /* 238 small i with circumflex accent */
+    "i\"",                      /* 239 small i with diaeresis */
+    NULL,                       /* 240 small icelandic eth */
+    NULL,                       /* 241 small n with tilde */
+    "o`",                       /* 242 small o with grave accent */
+    NULL,                       /* 243 small o with acute accent */
+    "o^",                       /* 244 small o with circumflex accent */
+    NULL,                       /* 245 small o with tilde */
+    "o\"",                      /* 246 small o with diaeresis */
+    NULL,                       /* 247 division sign */
+    NULL,                       /* 248 small o with oblique stroke */
+    "u`",                       /* 249 small u with grave accent */
+    NULL,                       /* 250 small u with acute accent */
+    "u^",                       /* 251 small u with circumflex accent */
+    "u\"",                      /* 252 small u with diaeresis */
+    NULL,                       /* 253 small y with acute accent */
+    NULL,                       /* 254 small icelandic thorn */
+    NULL,                       /* 255 small y with diaeresis */
   };
 
 static bool
 init_latin1_texte (RECODE_STEP step,
-		   const struct recode_request *request,
-		   RECODE_CONST_OPTION_LIST before_options,
-		   RECODE_CONST_OPTION_LIST after_options)
+                   const struct recode_request *request,
+                   RECODE_CONST_OPTION_LIST before_options,
+                   RECODE_CONST_OPTION_LIST after_options)
 {
   RECODE_OUTER outer = request->outer;
 
-  unsigned rewritten;		/* number of rewritten translations */
-  const char **table;		/* allocated structure, including pool */
-  char *pool;			/* cursor in character pool */
-  unsigned counter;		/* general purpose counter */
+  unsigned rewritten;           /* number of rewritten translations */
+  const char **table;           /* allocated structure, including pool */
+  char *pool;                   /* cursor in character pool */
+  unsigned counter;             /* general purpose counter */
 
   if (before_options || after_options)
     return false;
@@ -179,12 +179,12 @@ init_latin1_texte (RECODE_STEP step,
   if (request->diaeresis_char != '"')
     for (counter = 128; counter < 256; counter++)
       if (translation_table[counter - 128]
-	  && translation_table[counter - 128][1] == '"'
-	  && translation_table[counter - 128][2] == NUL)
-	rewritten++;
+          && translation_table[counter - 128][1] == '"'
+          && translation_table[counter - 128][2] == NUL)
+        rewritten++;
 
   if (!ALLOC_SIZE (table, sizeof (char *) * 256 + 2 * 128 + 3 * rewritten,
-		   const char *))
+                   const char *))
     return false;
   pool = (char *) (table + 256);
 
@@ -197,14 +197,14 @@ init_latin1_texte (RECODE_STEP step,
 
   for (; counter < 256; counter++)
     if (request->diaeresis_char != '"'
-	&& translation_table[counter - 128]
-	&& translation_table[counter - 128][1] == '"'
-	&& translation_table[counter - 128][2] == NUL)
+        && translation_table[counter - 128]
+        && translation_table[counter - 128][1] == '"'
+        && translation_table[counter - 128][2] == NUL)
       {
-	table[counter] = pool;
-	*pool++ = translation_table[counter - 128][0];
-	*pool++ = request->diaeresis_char;
-	*pool++ = NUL;
+        table[counter] = pool;
+        *pool++ = translation_table[counter - 128][0];
+        *pool++ = request->diaeresis_char;
+        *pool++ = NUL;
       }
     else
       table[counter] = translation_table[counter - 128];
@@ -220,8 +220,8 @@ module_latin1_texte (RECODE_OUTER outer)
 {
   return
     declare_single (outer, "Latin-1", "Texte",
-		    outer->quality_byte_to_variable,
-		    init_latin1_texte, transform_byte_to_variable)
+                    outer->quality_byte_to_variable,
+                    init_latin1_texte, transform_byte_to_variable)
     && declare_alias (outer, "txte", "Texte");
 }
 

--- a/src/ltexlat1.l
+++ b/src/ltexlat1.l
@@ -19,109 +19,109 @@
 
 /* Step name: latex_latin1.  */
 
-Letter			[a-zA-Z]
-Braces			[ \t]*(\{\})?
+Letter                  [a-zA-Z]
+Braces                  [ \t]*(\{\})?
 
 %%
 
-\\"#"				{ PUT_NON_DIACRITIC_BYTE ('#', subtask); }
-\\"$"				{ PUT_NON_DIACRITIC_BYTE ('$', subtask); }
-\\"%"				{ PUT_NON_DIACRITIC_BYTE ('%', subtask); }
-\\"&"				{ PUT_NON_DIACRITIC_BYTE ('&', subtask); }
-\\mbox"{$<$}"			{ PUT_NON_DIACRITIC_BYTE ('<', subtask); }
-\\mbox"{$>$}"			{ PUT_NON_DIACRITIC_BYTE ('>', subtask); }
-\\"_"				{ PUT_NON_DIACRITIC_BYTE ('_', subtask); }
-\\"{"				{ PUT_NON_DIACRITIC_BYTE ('{', subtask); }
-\\"}"				{ PUT_NON_DIACRITIC_BYTE ('}', subtask); }
+\\"#"                           { PUT_NON_DIACRITIC_BYTE ('#', subtask); }
+\\"$"                           { PUT_NON_DIACRITIC_BYTE ('$', subtask); }
+\\"%"                           { PUT_NON_DIACRITIC_BYTE ('%', subtask); }
+\\"&"                           { PUT_NON_DIACRITIC_BYTE ('&', subtask); }
+\\mbox"{$<$}"                   { PUT_NON_DIACRITIC_BYTE ('<', subtask); }
+\\mbox"{$>$}"                   { PUT_NON_DIACRITIC_BYTE ('>', subtask); }
+\\"_"                           { PUT_NON_DIACRITIC_BYTE ('_', subtask); }
+\\"{"                           { PUT_NON_DIACRITIC_BYTE ('{', subtask); }
+\\"}"                           { PUT_NON_DIACRITIC_BYTE ('}', subtask); }
 
-\\textasciicircum{Braces}	{ PUT_NON_DIACRITIC_BYTE ('^', subtask); }
-\\backslash{Braces}		{ PUT_NON_DIACRITIC_BYTE ('\\', subtask); }
+\\textasciicircum{Braces}       { PUT_NON_DIACRITIC_BYTE ('^', subtask); }
+\\backslash{Braces}             { PUT_NON_DIACRITIC_BYTE ('\\', subtask); }
 
-"~"				{ PUT_NON_DIACRITIC_BYTE (160, subtask); }
-"!`"				{ PUT_NON_DIACRITIC_BYTE (161, subtask); }
-\\pound{Braces}			{ PUT_NON_DIACRITIC_BYTE (163, subtask); }
-\\S{Braces}			{ PUT_NON_DIACRITIC_BYTE (167, subtask); }
-\\\"				{ PUT_NON_DIACRITIC_BYTE (168, subtask); }
-\\copyright{Braces}		{ PUT_NON_DIACRITIC_BYTE (169, subtask); }
-"``"				{ PUT_NON_DIACRITIC_BYTE (171, subtask); }
-\\neg{Braces}			{ PUT_NON_DIACRITIC_BYTE (172, subtask); }
-\\"-"				{ PUT_NON_DIACRITIC_BYTE (173, subtask); }
-\\mbox"{$^\\circ$}"		{ PUT_NON_DIACRITIC_BYTE (176, subtask); }
-\\mbox"{$\\pm$}"		{ PUT_NON_DIACRITIC_BYTE (177, subtask); }
-\\mbox"{$^2$}"			{ PUT_NON_DIACRITIC_BYTE (178, subtask); }
-\\mbox"{$^3$}"			{ PUT_NON_DIACRITIC_BYTE (179, subtask); }
-\\"'"				{ PUT_NON_DIACRITIC_BYTE (180, subtask); }
-\\mbox"{$\\mu$}"		{ PUT_NON_DIACRITIC_BYTE (181, subtask); }
-\\cdotp				{ PUT_NON_DIACRITIC_BYTE (183, subtask); }
-\\","				{ PUT_NON_DIACRITIC_BYTE (184, subtask); }
-\\mbox"{$^1$}"			{ PUT_NON_DIACRITIC_BYTE (185, subtask); }
-"''"				{ PUT_NON_DIACRITIC_BYTE (187, subtask); }
-\\frac"1/4"{Braces}		{ PUT_NON_DIACRITIC_BYTE (188, subtask); }
-\\frac"1/2"{Braces}		{ PUT_NON_DIACRITIC_BYTE (189, subtask); }
-\\frac"3/4"{Braces}		{ PUT_NON_DIACRITIC_BYTE (190, subtask); }
-"?`"				{ PUT_NON_DIACRITIC_BYTE (191, subtask); }
+"~"                             { PUT_NON_DIACRITIC_BYTE (160, subtask); }
+"!`"                            { PUT_NON_DIACRITIC_BYTE (161, subtask); }
+\\pound{Braces}                 { PUT_NON_DIACRITIC_BYTE (163, subtask); }
+\\S{Braces}                     { PUT_NON_DIACRITIC_BYTE (167, subtask); }
+\\\"                            { PUT_NON_DIACRITIC_BYTE (168, subtask); }
+\\copyright{Braces}             { PUT_NON_DIACRITIC_BYTE (169, subtask); }
+"``"                            { PUT_NON_DIACRITIC_BYTE (171, subtask); }
+\\neg{Braces}                   { PUT_NON_DIACRITIC_BYTE (172, subtask); }
+\\"-"                           { PUT_NON_DIACRITIC_BYTE (173, subtask); }
+\\mbox"{$^\\circ$}"             { PUT_NON_DIACRITIC_BYTE (176, subtask); }
+\\mbox"{$\\pm$}"                { PUT_NON_DIACRITIC_BYTE (177, subtask); }
+\\mbox"{$^2$}"                  { PUT_NON_DIACRITIC_BYTE (178, subtask); }
+\\mbox"{$^3$}"                  { PUT_NON_DIACRITIC_BYTE (179, subtask); }
+\\"'"                           { PUT_NON_DIACRITIC_BYTE (180, subtask); }
+\\mbox"{$\\mu$}"                { PUT_NON_DIACRITIC_BYTE (181, subtask); }
+\\cdotp                         { PUT_NON_DIACRITIC_BYTE (183, subtask); }
+\\","                           { PUT_NON_DIACRITIC_BYTE (184, subtask); }
+\\mbox"{$^1$}"                  { PUT_NON_DIACRITIC_BYTE (185, subtask); }
+"''"                            { PUT_NON_DIACRITIC_BYTE (187, subtask); }
+\\frac"1/4"{Braces}             { PUT_NON_DIACRITIC_BYTE (188, subtask); }
+\\frac"1/2"{Braces}             { PUT_NON_DIACRITIC_BYTE (189, subtask); }
+\\frac"3/4"{Braces}             { PUT_NON_DIACRITIC_BYTE (190, subtask); }
+"?`"                            { PUT_NON_DIACRITIC_BYTE (191, subtask); }
 
-\\"`"A|\\"`{A}"			{ put_byte (192, subtask); }
-\\"'"A|\\"'{A}"			{ put_byte (193, subtask); }
-\\"^"A|\\"^{A}"			{ put_byte (194, subtask); }
-\\"~"A|\\"~{A}"			{ put_byte (195, subtask); }
-\\\"A|\\\""{A}"			{ put_byte (196, subtask); }
-\\AA{Braces}			{ put_byte (197, subtask); }
-\\AE{Braces}			{ put_byte (198, subtask); }
-\\c[ \t]+C|\\c"{C}"		{ put_byte (199, subtask); }
-\\"`"E|\\"`{E}"			{ put_byte (200, subtask); }
-\\"'"E|\\"'{E}"			{ put_byte (201, subtask); }
-\\"^"E|\\"^{E}"			{ put_byte (202, subtask); }
-\\\"E|\\\""{E}"			{ put_byte (203, subtask); }
-\\"`"I|\\"`{I}"			{ put_byte (204, subtask); }
-\\"'"I|\\"'{I}"			{ put_byte (205, subtask); }
-\\"^"I|\\"^{I}"			{ put_byte (206, subtask); }
-\\\"I|\\\""{I}"			{ put_byte (207, subtask); }
-\\"~"N|\\"~{N}"			{ put_byte (209, subtask); }
-\\"`"O|\\"`{O}"			{ put_byte (210, subtask); }
-\\"'"O|\\"'{O}"			{ put_byte (211, subtask); }
-\\"^"O|\\"^{O}"			{ put_byte (212, subtask); }
-\\"~"O|\\"~{O}"			{ put_byte (213, subtask); }
-\\\"O|\\\""{O}"			{ put_byte (214, subtask); }
-\\O{Braces}			{ put_byte (216, subtask); }
-\\"`"U|\\"`{U}"			{ put_byte (217, subtask); }
-\\"'"U|\\"'{U}"			{ put_byte (218, subtask); }
-\\"^"U|\\"^{U}"			{ put_byte (219, subtask); }
-\\\"U|\\\""{U}"			{ put_byte (220, subtask); }
-\\"'"Y|\\"'{Y}"			{ put_byte (221, subtask); }
-\\ss{Braces}			{ put_byte (223, subtask); }
-\\"`"a|\\"`{a}"			{ put_byte (224, subtask); }
-\\"'"a|\\"'{a}"			{ put_byte (225, subtask); }
-\\"^"a|\\"^{a}"			{ put_byte (226, subtask); }
-\\"~"a|\\"~{a}"			{ put_byte (227, subtask); }
-\\\"a|\\\""{a}"			{ put_byte (228, subtask); }
-\\aa{Braces}			{ put_byte (229, subtask); }
-\\ae{Braces}			{ put_byte (230, subtask); }
-\\c[ \t]+c|\\c"{c}"		{ put_byte (231, subtask); }
-\\"`"e|\\"`{e}"			{ put_byte (232, subtask); }
-\\"'"e|\\"'{e}"			{ put_byte (233, subtask); }
-\\"^"e|\\"^{e}"			{ put_byte (234, subtask); }
-\\\"e|\\\""{e}"			{ put_byte (235, subtask); }
-\\"`"\\i{Braces}|\\"`{\\i}"	{ put_byte (236, subtask); }
-\\"'"\\i{Braces}|\\"'{\\i}"	{ put_byte (237, subtask); }
-\\"^"\\i{Braces}|\\"^{\\i}"	{ put_byte (238, subtask); }
-\\\"\\i{Braces}|\\\""{\\i}"	{ put_byte (239, subtask); }
-\\"~"n|\\"~{n}"			{ put_byte (241, subtask); }
-\\"`"o|\\"`{o}"			{ put_byte (242, subtask); }
-\\"'"o|\\"'{o}"			{ put_byte (243, subtask); }
-\\"^"o|\\"^{o}"			{ put_byte (244, subtask); }
-\\"~"o|\\"~{o}"			{ put_byte (245, subtask); }
-\\\"o|\\\""{o}"			{ put_byte (246, subtask); }
-\\o{Braces}			{ put_byte (248, subtask); }
-\\"`"u|\\"`{u}"			{ put_byte (249, subtask); }
-\\"'"u|\\"'{u}"			{ put_byte (250, subtask); }
-\\"^"u|\\"^{u}"			{ put_byte (251, subtask); }
-\\\"u|\\\""{u}"			{ put_byte (252, subtask); }
-\\"'"y|\\"'{y}"			{ put_byte (253, subtask); }
-\\\"y|\\\""{y}"			{ put_byte (255, subtask); }
+\\"`"A|\\"`{A}"                 { put_byte (192, subtask); }
+\\"'"A|\\"'{A}"                 { put_byte (193, subtask); }
+\\"^"A|\\"^{A}"                 { put_byte (194, subtask); }
+\\"~"A|\\"~{A}"                 { put_byte (195, subtask); }
+\\\"A|\\\""{A}"                 { put_byte (196, subtask); }
+\\AA{Braces}                    { put_byte (197, subtask); }
+\\AE{Braces}                    { put_byte (198, subtask); }
+\\c[ \t]+C|\\c"{C}"             { put_byte (199, subtask); }
+\\"`"E|\\"`{E}"                 { put_byte (200, subtask); }
+\\"'"E|\\"'{E}"                 { put_byte (201, subtask); }
+\\"^"E|\\"^{E}"                 { put_byte (202, subtask); }
+\\\"E|\\\""{E}"                 { put_byte (203, subtask); }
+\\"`"I|\\"`{I}"                 { put_byte (204, subtask); }
+\\"'"I|\\"'{I}"                 { put_byte (205, subtask); }
+\\"^"I|\\"^{I}"                 { put_byte (206, subtask); }
+\\\"I|\\\""{I}"                 { put_byte (207, subtask); }
+\\"~"N|\\"~{N}"                 { put_byte (209, subtask); }
+\\"`"O|\\"`{O}"                 { put_byte (210, subtask); }
+\\"'"O|\\"'{O}"                 { put_byte (211, subtask); }
+\\"^"O|\\"^{O}"                 { put_byte (212, subtask); }
+\\"~"O|\\"~{O}"                 { put_byte (213, subtask); }
+\\\"O|\\\""{O}"                 { put_byte (214, subtask); }
+\\O{Braces}                     { put_byte (216, subtask); }
+\\"`"U|\\"`{U}"                 { put_byte (217, subtask); }
+\\"'"U|\\"'{U}"                 { put_byte (218, subtask); }
+\\"^"U|\\"^{U}"                 { put_byte (219, subtask); }
+\\\"U|\\\""{U}"                 { put_byte (220, subtask); }
+\\"'"Y|\\"'{Y}"                 { put_byte (221, subtask); }
+\\ss{Braces}                    { put_byte (223, subtask); }
+\\"`"a|\\"`{a}"                 { put_byte (224, subtask); }
+\\"'"a|\\"'{a}"                 { put_byte (225, subtask); }
+\\"^"a|\\"^{a}"                 { put_byte (226, subtask); }
+\\"~"a|\\"~{a}"                 { put_byte (227, subtask); }
+\\\"a|\\\""{a}"                 { put_byte (228, subtask); }
+\\aa{Braces}                    { put_byte (229, subtask); }
+\\ae{Braces}                    { put_byte (230, subtask); }
+\\c[ \t]+c|\\c"{c}"             { put_byte (231, subtask); }
+\\"`"e|\\"`{e}"                 { put_byte (232, subtask); }
+\\"'"e|\\"'{e}"                 { put_byte (233, subtask); }
+\\"^"e|\\"^{e}"                 { put_byte (234, subtask); }
+\\\"e|\\\""{e}"                 { put_byte (235, subtask); }
+\\"`"\\i{Braces}|\\"`{\\i}"     { put_byte (236, subtask); }
+\\"'"\\i{Braces}|\\"'{\\i}"     { put_byte (237, subtask); }
+\\"^"\\i{Braces}|\\"^{\\i}"     { put_byte (238, subtask); }
+\\\"\\i{Braces}|\\\""{\\i}"     { put_byte (239, subtask); }
+\\"~"n|\\"~{n}"                 { put_byte (241, subtask); }
+\\"`"o|\\"`{o}"                 { put_byte (242, subtask); }
+\\"'"o|\\"'{o}"                 { put_byte (243, subtask); }
+\\"^"o|\\"^{o}"                 { put_byte (244, subtask); }
+\\"~"o|\\"~{o}"                 { put_byte (245, subtask); }
+\\\"o|\\\""{o}"                 { put_byte (246, subtask); }
+\\o{Braces}                     { put_byte (248, subtask); }
+\\"`"u|\\"`{u}"                 { put_byte (249, subtask); }
+\\"'"u|\\"'{u}"                 { put_byte (250, subtask); }
+\\"^"u|\\"^{u}"                 { put_byte (251, subtask); }
+\\\"u|\\\""{u}"                 { put_byte (252, subtask); }
+\\"'"y|\\"'{y}"                 { put_byte (253, subtask); }
+\\\"y|\\\""{y}"                 { put_byte (255, subtask); }
 
-\\[`'^"]\\i{Letter}*{Braces}	{ ECHO; }
-\\{Letter}+{Braces}		{ ECHO; }
+\\[`'^"]\\i{Letter}*{Braces}    { ECHO; }
+\\{Letter}+{Braces}             { ECHO; }
 
 %%
 

--- a/src/main.c
+++ b/src/main.c
@@ -185,11 +185,11 @@ GNU General Public License for more details.\n\
 \n\
 You should have received a copy of the GNU General Public License\n\
 along with this program; if not, see <https://www.gnu.org/licenses/>.\n"),
-	 stdout);
+         stdout);
 }
 
 /*-----------------------------------------------.
-| Explain how to use the program, then get out.	 |
+| Explain how to use the program, then get out.  |
 `-----------------------------------------------*/
 
 static void
@@ -197,13 +197,13 @@ usage (int status, bool list)
 {
   if (status != EXIT_SUCCESS)
     fprintf (stderr, _("Try `%s %s' for more information.\n"), program_name,
-	     list ? "--list" : "--help");
+             list ? "--list" : "--help");
   else
     {
       fputs (_("\
 Recode converts files between various character sets and surfaces.\n\
 "),
-	     stdout);
+             stdout);
       printf (_("\
 \n\
 Usage: %s [OPTION]... [ [CHARSET] | REQUEST [FILE]... ]\n"), program_name);
@@ -212,7 +212,7 @@ Usage: %s [OPTION]... [ [CHARSET] | REQUEST [FILE]... ]\n"), program_name);
 If a long option shows an argument as mandatory, then it is mandatory\n\
 for the equivalent short option also.  Similarly for optional arguments.\n\
 "),
-	     stdout);
+             stdout);
       fputs (_("\
 \n\
 Listings:\n\
@@ -224,7 +224,7 @@ Listings:\n\
       --help                 display this help and exit\n\
       --version              output version information and exit\n\
 "),
-	     stdout);
+             stdout);
       fputs (_("\
 \n\
 Operation modes:\n\
@@ -234,7 +234,7 @@ Operation modes:\n\
   -t, --touch             touch the recoded files after replacement\n\
   -i, -p, --sequence=STRATEGY  ignored for backwards compatibility\n\
 "),
-	     stdout);
+             stdout);
       fputs (_("\
 \n\
 Fine tuning:\n\
@@ -247,26 +247,26 @@ Fine tuning:\n\
   -x, --ignore=CHARSET   ignore CHARSET while choosing a recoding path\n\
   -I, --prefer-iconv     use iconv if possible\n\
 "),
-	     stdout);
+             stdout);
       fputs (_("\
 \n\
 Option -l with no FORMAT nor CHARSET list available charsets and surfaces.\n\
 FORMAT is `decimal', `octal', `hexadecimal' or `full' (or one of `dohf').\n\
 "),
-	     stdout);
+             stdout);
       fputs (_("\
 Unless DEFAULT_CHARSET is set in environment, CHARSET defaults to the locale\n\
 dependent encoding, determined by LC_ALL, LC_CTYPE, LANG.\n\
 "),
-	       stdout);
+               stdout);
       fputs (_("\
 With -k, possible before charsets are listed for the given after CHARSET,\n\
 both being tabular charsets, with PAIRS of the form `BEF1:AFT1,BEF2:AFT2,...'\n\
 and BEFs and AFTs being codes are given as decimal numbers.\n"),
-	      stdout);
+              stdout);
       fputs (_("\
 LN is some language, it may be `c', `perl' or `po'; `c' is the default.\n"),
-	     stdout);
+             stdout);
       fputs (_("\
 \n\
 REQUEST is SUBREQUEST[,SUBREQUEST]...; SUBREQUEST is ENCODING[..ENCODING]...\n\
@@ -274,23 +274,23 @@ ENCODING is [CHARSET][/[SURFACE]]...; REQUEST often looks like BEFORE..AFTER,\n\
 with BEFORE and AFTER being charsets.  An omitted CHARSET implies the usual\n\
 charset; an omitted [/SURFACE]... means the implied surfaces for CHARSET; a /\n\
 with an empty surface name means no surfaces at all.  See the manual.\n"),
-	     stdout);
+             stdout);
       fputs (_("\
 \n\
 Each FILE is recoded over itself, destroying the original.  If no\n\
 FILE is specified, then act as a filter and recode stdin to stdout.\n"),
-	     stdout);
+             stdout);
       fputs (_("\
 \n\
 Report bugs at https://github.com/rrthomas/recode\n"),
-	       stdout);
+               stdout);
     }
   exit (status);
 }
 
 /*----------------------------------------------------------------------.
 | Main program.  Decode ARGC arguments passed through the ARGV array of |
-| strings, then launch execution.				        |
+| strings, then launch execution.                                       |
 `----------------------------------------------------------------------*/
 
 /* Long options equivalences.  */
@@ -351,13 +351,13 @@ new_outer(unsigned flags)
   if (ignored_name)
     {
       RECODE_ALIAS alias
-	= find_alias (outer, ignored_name, ALIAS_FIND_AS_CHARSET);
+        = find_alias (outer, ignored_name, ALIAS_FIND_AS_CHARSET);
 
       if (!alias)
-	{
-	  error (0, 0, _("Symbol `%s' is unknown"), ignored_name);
-	  usage (EXIT_FAILURE, 1);
-	}
+        {
+          error (0, 0, _("Symbol `%s' is unknown"), ignored_name);
+          usage (EXIT_FAILURE, 1);
+        }
 
       alias->symbol->ignore = true;
     }
@@ -379,8 +379,8 @@ new_request(RECODE_OUTER outer, struct recode_request *request_option)
 int
 main (int argc, char *const *argv)
 {
-  int option_char;		/* option character */
-  bool success = true;		/* reversibility of all recodings */
+  int option_char;              /* option character */
+  bool success = true;          /* reversibility of all recodings */
 
   static bool (*processor) (RECODE_TASK);
   struct recode_outer outer_option;
@@ -411,209 +411,209 @@ main (int argc, char *const *argv)
   task_option.abort_level = RECODE_AMBIGUOUS_OUTPUT;
 
   while (option_char = getopt_long (argc, argv, "CIFS::Tcdfgh::ik:l::pqstvx:",
-				    long_options, NULL),
-	 option_char != -1)
+                                    long_options, NULL),
+         option_char != -1)
     switch (option_char)
       {
       default:
-	usage (EXIT_FAILURE, 0);
+        usage (EXIT_FAILURE, 0);
 
       case NUL:
-	break;
+        break;
 
       case '\n':
-	switch (argmatch (optarg, sequence_strings, NULL, 0))
-	  {
-	  case -2:
-	    error (0, 0, _("Sequence `%s' is ambiguous"), optarg);
-	    usage (EXIT_FAILURE, 0);
+        switch (argmatch (optarg, sequence_strings, NULL, 0))
+          {
+          case -2:
+            error (0, 0, _("Sequence `%s' is ambiguous"), optarg);
+            usage (EXIT_FAILURE, 0);
             break;
 
-	  case -1:
-	    error (0, 0, _("Sequence `%s' is unknown"), optarg);
-	    usage (EXIT_FAILURE, 0);
+          case -1:
+            error (0, 0, _("Sequence `%s' is unknown"), optarg);
+            usage (EXIT_FAILURE, 0);
             break;
 
             /* Ignore for backwards compatibility with version 3.6.  */
-	  case 0:
-	  case 1:
-	  case 2:
-	    break;
+          case 0:
+          case 1:
+          case 2:
+            break;
 
           default:
             break;
-	  }
-	break;
+          }
+        break;
 
       case 'C':
-	print_copyright ();
-	exit (EXIT_SUCCESS);
+        print_copyright ();
+        exit (EXIT_SUCCESS);
 
       case 'I':
         prefer_iconv = true;
         break;
 
       case 'S':
-	if (optarg)
-	  switch (argmatch (optarg, language_strings, NULL, 0))
-	    {
-	    case -2:
-	      error (0, 0, _("Language `%s' is ambiguous"), optarg);
-	      usage (EXIT_FAILURE, 0);
+        if (optarg)
+          switch (argmatch (optarg, language_strings, NULL, 0))
+            {
+            case -2:
+              error (0, 0, _("Language `%s' is ambiguous"), optarg);
+              usage (EXIT_FAILURE, 0);
               break;
 
-	    default:		/* -1 */
-	      error (0, 0, _("Language `%s' is unknown"), optarg);
-	      usage (EXIT_FAILURE, 0);
+            default:            /* -1 */
+              error (0, 0, _("Language `%s' is unknown"), optarg);
+              usage (EXIT_FAILURE, 0);
               break;
 
-	    case 0:
-	      processor = transform_c_source;
-	      break;
+            case 0:
+              processor = transform_c_source;
+              break;
 
-	    case 2:
-	      processor = transform_po_source;
-	      break;
-	    }
-	else
-	  processor = transform_c_source;
-	break;
+            case 2:
+              processor = transform_po_source;
+              break;
+            }
+        else
+          processor = transform_c_source;
+        break;
 
       case 'T':
-	find_subsets = true;
-	break;
+        find_subsets = true;
+        break;
 
       case 'c':
-	request_option.diaeresis_char = ':';
-	break;
+        request_option.diaeresis_char = ':';
+        break;
 
       case 'd':
-	request_option.diacritics_only = true;
-	break;
+        request_option.diacritics_only = true;
+        break;
 
       case 'f':
-	task_option.fail_level = RECODE_SYSTEM_ERROR;
-	task_option.abort_level = RECODE_USER_ERROR;
+        task_option.fail_level = RECODE_SYSTEM_ERROR;
+        task_option.abort_level = RECODE_USER_ERROR;
         force_flag = true;
-	break;
+        break;
 
       case 'g':
-	request_option.ascii_graphics = true;
-	break;
+        request_option.ascii_graphics = true;
+        break;
 
       case 'h':
-	request_option.make_header_flag = true;
-	header_name = optarg ? strrchr (optarg, '/') : NULL;
-	if (header_name)
-	  {
-	    char *buffer;
-	    unsigned counter;
+        request_option.make_header_flag = true;
+        header_name = optarg ? strrchr (optarg, '/') : NULL;
+        if (header_name)
+          {
+            char *buffer;
+            unsigned counter;
 
-	    header_name++;
-	    buffer = (char *) xmalloc ((size_t) (header_name - optarg));
-	    if (*header_name == NUL)
-	      header_name = NULL;
-	    for (counter = 0; optarg[counter] != '/'; counter++)
-	      buffer[counter] = tolower (optarg[counter]);
-	    buffer[counter] = NUL;
-	    switch (argmatch (buffer, language_strings, NULL, 0))
-	      {
-	      case -2:
-		error (0, 0, _("Language `%s' is ambiguous"), buffer);
-		usage (EXIT_FAILURE, 0);
+            header_name++;
+            buffer = (char *) xmalloc ((size_t) (header_name - optarg));
+            if (*header_name == NUL)
+              header_name = NULL;
+            for (counter = 0; optarg[counter] != '/'; counter++)
+              buffer[counter] = tolower (optarg[counter]);
+            buffer[counter] = NUL;
+            switch (argmatch (buffer, language_strings, NULL, 0))
+              {
+              case -2:
+                error (0, 0, _("Language `%s' is ambiguous"), buffer);
+                usage (EXIT_FAILURE, 0);
                 break;
 
-	      default:		/* -1 */
-		error (0, 0, _("Language `%s' is unknown"), buffer);
-		usage (EXIT_FAILURE, 0);
+              default:          /* -1 */
+                error (0, 0, _("Language `%s' is unknown"), buffer);
+                usage (EXIT_FAILURE, 0);
                 break;
 
-	      case 0:
-		header_language = RECODE_LANGUAGE_C;
-		break;
+              case 0:
+                header_language = RECODE_LANGUAGE_C;
+                break;
 
-	      case 1:
-		header_language = RECODE_LANGUAGE_PERL;
-		break;
-	      }
-	    free (buffer);
-	  }
-	else
-	  {
-	    header_name = optarg;
-	    header_language = RECODE_LANGUAGE_C;
-	  }
-	break;
+              case 1:
+                header_language = RECODE_LANGUAGE_PERL;
+                break;
+              }
+            free (buffer);
+          }
+        else
+          {
+            header_name = optarg;
+            header_language = RECODE_LANGUAGE_C;
+          }
+        break;
 
       case 'i':
         /* Ignore for backwards compatibility with version 3.6.  */
-	break;
+        break;
 
       case 'k':
-	charset_restrictions = optarg;
-	break;
+        charset_restrictions = optarg;
+        break;
 
       case 'l':
-	show_symbols = true;
-	if (optarg)
-	  switch (argmatch (optarg, format_strings, NULL, 0))
-	    {
-	    case -2:
-	      error (0, 0, _("Format `%s' is ambiguous"), optarg);
-	      usage (EXIT_FAILURE, 0);
+        show_symbols = true;
+        if (optarg)
+          switch (argmatch (optarg, format_strings, NULL, 0))
+            {
+            case -2:
+              error (0, 0, _("Format `%s' is ambiguous"), optarg);
+              usage (EXIT_FAILURE, 0);
               break;
 
-	    case -1:
-	      error (0, 0, _("Format `%s' is unknown"), optarg);
-	      usage (EXIT_FAILURE, 0);
+            case -1:
+              error (0, 0, _("Format `%s' is unknown"), optarg);
+              usage (EXIT_FAILURE, 0);
               break;
 
-	    case 0:
-	      list_format = RECODE_DECIMAL_FORMAT;
-	      break;
+            case 0:
+              list_format = RECODE_DECIMAL_FORMAT;
+              break;
 
-	    case 1:
-	      list_format = RECODE_OCTAL_FORMAT;
-	      break;
+            case 1:
+              list_format = RECODE_OCTAL_FORMAT;
+              break;
 
-	    case 2:
-	      list_format = RECODE_HEXADECIMAL_FORMAT;
-	      break;
+            case 2:
+              list_format = RECODE_HEXADECIMAL_FORMAT;
+              break;
 
-	    case 3:
-	      list_format = RECODE_FULL_FORMAT;
-	      break;
+            case 3:
+              list_format = RECODE_FULL_FORMAT;
+              break;
 
             default:
               break;
-	    }
-	break;
+            }
+        break;
 
       case 'p':
         /* Ignore for backwards compatibility with version 3.6.  */
-	break;
+        break;
 
       case 'q':
-	quiet_flag = true;
-	break;
+        quiet_flag = true;
+        break;
 
       case 's':
-	strict_mapping = true;
-	task_option.fail_level = RECODE_NOT_CANONICAL;
-	task_option.abort_level = RECODE_NOT_CANONICAL;
-	break;
+        strict_mapping = true;
+        task_option.fail_level = RECODE_NOT_CANONICAL;
+        task_option.abort_level = RECODE_NOT_CANONICAL;
+        break;
 
       case 't':
-	touch_option = true;
-	break;
+        touch_option = true;
+        break;
 
       case 'v':
-	verbose_flag = true;
+        verbose_flag = true;
         break;
 
       case 'x':
-	ignored_name = optarg;
-	break;
+        ignored_name = optarg;
+        break;
       }
 
   if (request_option.ascii_graphics)
@@ -626,15 +626,15 @@ main (int argc, char *const *argv)
       printf ("%s %s\n", PACKAGE, VERSION);
       fputs (_("\
 Written by François Pinard <pinard@iro.umontreal.ca>.\n"),
-	     stdout);
+             stdout);
       fputs (_("\
 \n\
 Copyright (C) 1990-2022 Free Software Foundation, Inc.\n"),
-	     stdout);
+             stdout);
       fputs (_("\
 This is free software; see the source for copying conditions.  There is NO\n\
 warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n"),
-	     stdout);
+             stdout);
       exit (EXIT_SUCCESS);
     }
 
@@ -664,62 +664,62 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n"),
   if (show_symbols || charset_restrictions)
     {
       if (charset_restrictions)
-	if (!decode_known_pairs (outer, charset_restrictions))
-	  {
-	    error (0, 0, "Could not understand `%s'", charset_restrictions);
-	    usage (EXIT_FAILURE, 0);
+        if (!decode_known_pairs (outer, charset_restrictions))
+          {
+            error (0, 0, "Could not understand `%s'", charset_restrictions);
+            usage (EXIT_FAILURE, 0);
 
-	  }
+          }
       if (optind + 1 < argc)
-	{
-	  error (0, 0, "Argument `%s' is extraneous", argv[optind]);
-	  usage (EXIT_FAILURE, 0);
-	}
+        {
+          error (0, 0, "Argument `%s' is extraneous", argv[optind]);
+          usage (EXIT_FAILURE, 0);
+        }
 
       /* Select a possible charset and a default format.  */
 
       if (optind < argc)
-	{
-	  RECODE_ALIAS alias
-	    = find_alias (outer, argv[optind], ALIAS_FIND_AS_CHARSET);
+        {
+          RECODE_ALIAS alias
+            = find_alias (outer, argv[optind], ALIAS_FIND_AS_CHARSET);
 
-	  if (!alias)
-	    {
-	      error (0, 0, _("Charset `%s' is unknown or ambiguous"),
-		     argv[optind]);
-	      usage (EXIT_FAILURE, 1);
-	    }
+          if (!alias)
+            {
+              error (0, 0, _("Charset `%s' is unknown or ambiguous"),
+                     argv[optind]);
+              usage (EXIT_FAILURE, 1);
+            }
 
-	  list_charset = alias->symbol;
-	}
+          list_charset = alias->symbol;
+        }
       else if (list_format != RECODE_NO_FORMAT || charset_restrictions)
-	{
-	  RECODE_ALIAS alias
-	    = find_alias (outer, NULL, ALIAS_FIND_AS_CHARSET);
+        {
+          RECODE_ALIAS alias
+            = find_alias (outer, NULL, ALIAS_FIND_AS_CHARSET);
 
-	  if (!alias)
-	    {
-	      error (0, 0, _("Charset `%s' is unknown or ambiguous"),
-		     argv[optind]);
-	      usage (EXIT_FAILURE, 1);
-	    }
+          if (!alias)
+            {
+              error (0, 0, _("Charset `%s' is unknown or ambiguous"),
+                     argv[optind]);
+              usage (EXIT_FAILURE, 1);
+            }
 
-	  list_charset = alias->symbol;
-	}
+          list_charset = alias->symbol;
+        }
       else
-	list_charset = NULL;
+        list_charset = NULL;
 
       /* List the charset(s) appropriately.  */
 
       if (charset_restrictions)
-	list_all_symbols (outer, list_charset);
+        list_all_symbols (outer, list_charset);
       else if (list_charset)
-	if (list_format == RECODE_FULL_FORMAT)
-	  list_full_charset (outer, list_charset);
-	else
-	  list_concise_charset (outer, list_charset, list_format);
+        if (list_format == RECODE_FULL_FORMAT)
+          list_full_charset (outer, list_charset);
+        else
+          list_concise_charset (outer, list_charset, list_format);
       else
-	list_all_symbols (outer, NULL);
+        list_all_symbols (outer, NULL);
 
       /* Then get out.  */
 
@@ -793,144 +793,144 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n"),
 
     if (optind < argc)
       {
-	/* In case files are recoded over themselves and there is no
-	   recoding step at all, do not even try to touch the files.  */
+        /* In case files are recoded over themselves and there is no
+           recoding step at all, do not even try to touch the files.  */
 
-	if (request->sequence_length > 0)
+        if (request->sequence_length > 0)
 
-	  /* Process files, one at a time.  */
+          /* Process files, one at a time.  */
 
-	  for (; optind < argc; optind++)
-	    {
-	      const char *input_name;
-	      FILE *file;
-	      struct stat file_stat;
-	      struct utimbuf file_utime;
+          for (; optind < argc; optind++)
+            {
+              const char *input_name;
+              FILE *file;
+              struct stat file_stat;
+              struct utimbuf file_utime;
 
-	      input_name = realpath (argv[optind], NULL);
-	      if (input_name == NULL)
-		error (EXIT_FAILURE, errno, "realpath (%s)", argv[optind]);
+              input_name = realpath (argv[optind], NULL);
+              if (input_name == NULL)
+                error (EXIT_FAILURE, errno, "realpath (%s)", argv[optind]);
 
-	      /* Check if the file can be read and rewritten.  */
+              /* Check if the file can be read and rewritten.  */
 
-	      if (file = fopen (input_name, "r+"), file == NULL)
-		error (EXIT_FAILURE, errno, "fopen (%s)", input_name);
+              if (file = fopen (input_name, "r+"), file == NULL)
+                error (EXIT_FAILURE, errno, "fopen (%s)", input_name);
 
-	      /* Save the input file attributes.  */
+              /* Save the input file attributes.  */
 
-	      fstat (fileno (file), &file_stat);
-	      fclose (file);
+              fstat (fileno (file), &file_stat);
+              fclose (file);
 
-	      /* Choose an output file in the same directory.  */
+              /* Choose an output file in the same directory.  */
 
-	      char *input_name_copy = xstrdup (input_name);
-	      char *output_dir = dirname (input_name_copy);
-	      char *output_name;
-	      if (asprintf (&output_name, "%s/recode-XXXXXX.tmp", output_dir) == -1)
-		error (EXIT_FAILURE, errno, "asprintf");
-	      int fd = mkstemps (output_name, 4);
-	      if (fd == -1)
-		error (EXIT_FAILURE, errno, "mkstemps (%s)", output_name);
-	      xset_binary_mode (fd, O_BINARY);
+              char *input_name_copy = xstrdup (input_name);
+              char *output_dir = dirname (input_name_copy);
+              char *output_name;
+              if (asprintf (&output_name, "%s/recode-XXXXXX.tmp", output_dir) == -1)
+                error (EXIT_FAILURE, errno, "asprintf");
+              int fd = mkstemps (output_name, 4);
+              if (fd == -1)
+                error (EXIT_FAILURE, errno, "mkstemps (%s)", output_name);
+              xset_binary_mode (fd, O_BINARY);
 
-	      /* Recode the file.  */
+              /* Recode the file.  */
 
-	      task->input.name = input_name;
-	      task->output.name = NULL;
-	      task->output.file = fdopen (fd, "w+");
-	      if (task->output.file == NULL)
-	      	error (EXIT_FAILURE, errno, "fdopen ()");
+              task->input.name = input_name;
+              task->output.name = NULL;
+              task->output.file = fdopen (fd, "w+");
+              if (task->output.file == NULL)
+                error (EXIT_FAILURE, errno, "fdopen ()");
 
-	      if (verbose_flag)
-		{
-		  fprintf (stderr, _("Recoding %s..."), task->input.name);
-		  fflush (stderr);
-		}
+              if (verbose_flag)
+                {
+                  fprintf (stderr, _("Recoding %s..."), task->input.name);
+                  fflush (stderr);
+                }
 
-	      if ((*processor) (task))
-		{
-		  /* Recoding was successful.  */
+              if ((*processor) (task))
+                {
+                  /* Recoding was successful.  */
 
-		  if (verbose_flag)
-		    {
-		      fprintf (stderr, _(" done\n"));
-		      fflush (stderr);
-		    }
+                  if (verbose_flag)
+                    {
+                      fprintf (stderr, _(" done\n"));
+                      fflush (stderr);
+                    }
 
                   /* Close the file. */
 
                   if (fclose (task->output.file) == EOF)
                     error (EXIT_FAILURE, errno, "close ()");
 
-		  /* Move the new file over the original.  */
+                  /* Move the new file over the original.  */
 
-		  if (unlink (input_name) < 0)
-		    error (EXIT_FAILURE, errno, "unlink (%s)", input_name);
+                  if (unlink (input_name) < 0)
+                    error (EXIT_FAILURE, errno, "unlink (%s)", input_name);
 
-		  /* Preserve the file permissions if possible.  */
+                  /* Preserve the file permissions if possible.  */
 
-		  chmod (output_name, file_stat.st_mode & 07777);
+                  chmod (output_name, file_stat.st_mode & 07777);
 
-		  if (rename (output_name, input_name) < 0)
-		    error (EXIT_FAILURE, errno, "rename (%s, %s)",
-			   output_name, input_name);
+                  if (rename (output_name, input_name) < 0)
+                    error (EXIT_FAILURE, errno, "rename (%s, %s)",
+                           output_name, input_name);
 
-		  /* Adjust the time stamp for the new file.  */
+                  /* Adjust the time stamp for the new file.  */
 
-		  if (!touch_option)
-		    {
-		      file_utime.actime = file_stat.st_atime;
-		      file_utime.modtime = file_stat.st_mtime;
-		      utime (input_name, &file_utime);
-		    }
-		}
-	      else
-		{
-		  /* Recoding failed, discard output.  */
+                  if (!touch_option)
+                    {
+                      file_utime.actime = file_stat.st_atime;
+                      file_utime.modtime = file_stat.st_mtime;
+                      utime (input_name, &file_utime);
+                    }
+                }
+              else
+                {
+                  /* Recoding failed, discard output.  */
 
-		  success = false;
-		  if (verbose_flag)
-		    {
-		      fprintf (stderr, _(" failed: %s%s%s%s%s%s\n"),
-			       task_perror (task),
+                  success = false;
+                  if (verbose_flag)
+                    {
+                      fprintf (stderr, _(" failed: %s%s%s%s%s%s\n"),
+                               task_perror (task),
                                task->error_at_step ? _(" in step `") : "",
-			       task->error_at_step ? task->error_at_step->before->name : "",
+                               task->error_at_step ? task->error_at_step->before->name : "",
                                task->error_at_step ? _("..") : "",
-			       task->error_at_step ? task->error_at_step->after->name : "",
+                               task->error_at_step ? task->error_at_step->after->name : "",
                                task->error_at_step ? _("'") : "");
-		      fflush (stderr);
-		    }
-		  else if (!quiet_flag)
-		    error (0, 0, _("%s failed: %s%s%s%s%s%s"),
-			   input_name, task_perror (task),
+                      fflush (stderr);
+                    }
+                  else if (!quiet_flag)
+                    error (0, 0, _("%s failed: %s%s%s%s%s%s"),
+                           input_name, task_perror (task),
                            task->error_at_step ? _(" in step `") : "",
                            task->error_at_step ? task->error_at_step->before->name : "",
                            task->error_at_step ? _("..") : "",
                            task->error_at_step ? task->error_at_step->after->name : "",
                            task->error_at_step ? _("'") : "");
 
-		  unlink (output_name);
-		}
-	      free (output_name);
-	      free (input_name_copy);
-	    }
+                  unlink (output_name);
+                }
+              free (output_name);
+              free (input_name_copy);
+            }
       }
     else
       {
-	task->input.name = "";
-	task->output.name = "";
-	if (!(*processor) (task))
-	  {
-	    success = false;
-	    if (!quiet_flag)
-	      error (0, 0, _("%s%s%s%s%s%s"),
-		     task_perror (task),
+        task->input.name = "";
+        task->output.name = "";
+        if (!(*processor) (task))
+          {
+            success = false;
+            if (!quiet_flag)
+              error (0, 0, _("%s%s%s%s%s%s"),
+                     task_perror (task),
                      task->error_at_step ? _(" in step `") : "",
                      task->error_at_step ? task->error_at_step->before->name : "",
                      task->error_at_step ? _("..") : "",
                      task->error_at_step ? task->error_at_step->after->name : "",
                      task->error_at_step ? _("'") : "");
-	  }
+          }
       }
   }
 

--- a/src/mixed.c
+++ b/src/mixed.c
@@ -48,7 +48,7 @@ open_mixed (struct mixed *mixed, RECODE_TASK task)
   if (!*(task->input.name))
     task->input.file = stdin;
   else if (task->input.file = fopen (mixed->input_name, "rb"),
-	   !task->input.file)
+           !task->input.file)
     {
       recode_perror (NULL, "fopen (%s)", task->input.name);
       return false;
@@ -58,7 +58,7 @@ open_mixed (struct mixed *mixed, RECODE_TASK task)
   if (!*(task->output.name))
     task->output.file = stdout;
   else if (task->output.file = fopen (mixed->output_name, "wb"),
-	   !task->output.file)
+           !task->output.file)
     {
       recode_perror (NULL, "fopen (%s)", task->output.name);
       fclose (task->input.file);
@@ -135,150 +135,150 @@ transform_c_source (RECODE_TASK task)
     {
       character = get_byte (&mixed.subtask);
       while (character != EOF)
-	switch (character)
-	  {
-	  case '\'':
-	    /* Skip character constant, while copying it untranslated.  */
+        switch (character)
+          {
+          case '\'':
+            /* Skip character constant, while copying it untranslated.  */
 
-	    put_byte ('\'', &mixed.subtask);
-	    character = get_byte (&mixed.subtask);
+            put_byte ('\'', &mixed.subtask);
+            character = get_byte (&mixed.subtask);
 
-	    if (character == EOF)
-	      {
-		recode_if_nogo (RECODE_SYSTEM_ERROR, &mixed.subtask);
-		break;
-	      }
+            if (character == EOF)
+              {
+                recode_if_nogo (RECODE_SYSTEM_ERROR, &mixed.subtask);
+                break;
+              }
 
-	    if (character == '\\')
-	      {
-		put_byte ('\\', &mixed.subtask);
-		character = get_byte (&mixed.subtask);
-		if (character == EOF)
-		  {
-		    recode_if_nogo (RECODE_SYSTEM_ERROR, &mixed.subtask);
-		    break;
-		  }
-		put_byte (character, &mixed.subtask);
-		character = get_byte (&mixed.subtask);
-	      }
+            if (character == '\\')
+              {
+                put_byte ('\\', &mixed.subtask);
+                character = get_byte (&mixed.subtask);
+                if (character == EOF)
+                  {
+                    recode_if_nogo (RECODE_SYSTEM_ERROR, &mixed.subtask);
+                    break;
+                  }
+                put_byte (character, &mixed.subtask);
+                character = get_byte (&mixed.subtask);
+              }
 
-	    if (character == '\'')
-	      {
-		put_byte ('\'', &mixed.subtask);
-		character = get_byte (&mixed.subtask);
-	      }
-	    else
-	      recode_if_nogo (RECODE_SYSTEM_ERROR, &mixed.subtask);
-	    break;
+            if (character == '\'')
+              {
+                put_byte ('\'', &mixed.subtask);
+                character = get_byte (&mixed.subtask);
+              }
+            else
+              recode_if_nogo (RECODE_SYSTEM_ERROR, &mixed.subtask);
+            break;
 
-	  case '"':
-	    /* Copy the string, translated.  */
+          case '"':
+            /* Copy the string, translated.  */
 
-	    put_byte ('"', &mixed.subtask);
-	    character = get_byte (&mixed.subtask);
+            put_byte ('"', &mixed.subtask);
+            character = get_byte (&mixed.subtask);
 
-	    /* Read in string.  */
+            /* Read in string.  */
 
-	    start_accumulation (&mixed);
+            start_accumulation (&mixed);
 
-	    while (true)
-	      {
-		if (character == EOF)
-		  {
-		    recode_accumulated (&mixed);
-		    recode_if_nogo (RECODE_SYSTEM_ERROR, &mixed.subtask);
-		    break;
-		  }
-		if (character == '"')
-		  break;
+            while (true)
+              {
+                if (character == EOF)
+                  {
+                    recode_accumulated (&mixed);
+                    recode_if_nogo (RECODE_SYSTEM_ERROR, &mixed.subtask);
+                    break;
+                  }
+                if (character == '"')
+                  break;
 
-		if (character == '\\')
-		  {
-		    put_byte ('\\', &mixed.subtask);
-		    character = get_byte (&mixed.subtask);
-		    if (character == EOF)
-		      {
-			recode_accumulated (&mixed);
-			recode_if_nogo (RECODE_SYSTEM_ERROR, &mixed.subtask);
-			break;
-		      }
-		  }
-		put_byte (character, &mixed.subtask);
-		character = get_byte (&mixed.subtask);
-	      }
-	    if (character == EOF)
-	      break;
+                if (character == '\\')
+                  {
+                    put_byte ('\\', &mixed.subtask);
+                    character = get_byte (&mixed.subtask);
+                    if (character == EOF)
+                      {
+                        recode_accumulated (&mixed);
+                        recode_if_nogo (RECODE_SYSTEM_ERROR, &mixed.subtask);
+                        break;
+                      }
+                  }
+                put_byte (character, &mixed.subtask);
+                character = get_byte (&mixed.subtask);
+              }
+            if (character == EOF)
+              break;
 
-	    /* Translate string and dump it.  */
+            /* Translate string and dump it.  */
 
-	    if (!recode_accumulated (&mixed))
-	      recode_if_nogo (RECODE_SYSTEM_ERROR, &mixed.subtask);
-	    put_byte ('"', &mixed.subtask);
-	    character = get_byte (&mixed.subtask);
-	    break;
+            if (!recode_accumulated (&mixed))
+              recode_if_nogo (RECODE_SYSTEM_ERROR, &mixed.subtask);
+            put_byte ('"', &mixed.subtask);
+            character = get_byte (&mixed.subtask);
+            break;
 
-	  case '/':
-	    put_byte ('/', &mixed.subtask);
-	    character = get_byte (&mixed.subtask);
-	    if (character == EOF)
-	      break;
-	    if (character == '*')
-	      {
-		/* Copy the comment, translated.  */
+          case '/':
+            put_byte ('/', &mixed.subtask);
+            character = get_byte (&mixed.subtask);
+            if (character == EOF)
+              break;
+            if (character == '*')
+              {
+                /* Copy the comment, translated.  */
 
-		put_byte ('*', &mixed.subtask);
-		character = get_byte (&mixed.subtask);
+                put_byte ('*', &mixed.subtask);
+                character = get_byte (&mixed.subtask);
 
-		/* Read in comment.  */
+                /* Read in comment.  */
 
-		start_accumulation (&mixed);
-		while (true)
-		  {
-		    if (character == EOF)
-		      {
-			recode_accumulated (&mixed);
-			recode_if_nogo (RECODE_SYSTEM_ERROR, &mixed.subtask);
-			break;
-		      }
-		    if (character == '*')
-		      {
-			character = get_byte (&mixed.subtask);
-			if (character == EOF)
-			  {
-			    recode_accumulated (&mixed);
-			    recode_if_nogo (RECODE_SYSTEM_ERROR, &mixed.subtask);
-			    put_byte ('*', &mixed.subtask);
-			    break;
-			  }
-			if (character == '/')
-			  break;
-			put_byte ('*', &mixed.subtask);
-		      }
-		    else
-		      {
-			put_byte (character, &mixed.subtask);
-			character = get_byte (&mixed.subtask);
-		      }
-		  }
+                start_accumulation (&mixed);
+                while (true)
+                  {
+                    if (character == EOF)
+                      {
+                        recode_accumulated (&mixed);
+                        recode_if_nogo (RECODE_SYSTEM_ERROR, &mixed.subtask);
+                        break;
+                      }
+                    if (character == '*')
+                      {
+                        character = get_byte (&mixed.subtask);
+                        if (character == EOF)
+                          {
+                            recode_accumulated (&mixed);
+                            recode_if_nogo (RECODE_SYSTEM_ERROR, &mixed.subtask);
+                            put_byte ('*', &mixed.subtask);
+                            break;
+                          }
+                        if (character == '/')
+                          break;
+                        put_byte ('*', &mixed.subtask);
+                      }
+                    else
+                      {
+                        put_byte (character, &mixed.subtask);
+                        character = get_byte (&mixed.subtask);
+                      }
+                  }
 
-		if (character == EOF)
-		  break;
+                if (character == EOF)
+                  break;
 
-		/* Translate comment and dump it.  */
+                /* Translate comment and dump it.  */
 
-		if (!recode_accumulated (&mixed))
-		  recode_if_nogo (RECODE_SYSTEM_ERROR, &mixed.subtask);
-		put_byte ('*', &mixed.subtask);
-		put_byte ('/', &mixed.subtask);
-		character = get_byte (&mixed.subtask);
-	      }
-	    break;
+                if (!recode_accumulated (&mixed))
+                  recode_if_nogo (RECODE_SYSTEM_ERROR, &mixed.subtask);
+                put_byte ('*', &mixed.subtask);
+                put_byte ('/', &mixed.subtask);
+                character = get_byte (&mixed.subtask);
+              }
+            break;
 
-	  default:
-	    put_byte (character, &mixed.subtask);
-	    character = get_byte (&mixed.subtask);
-	    break;
-	  }
+          default:
+            put_byte (character, &mixed.subtask);
+            character = get_byte (&mixed.subtask);
+            break;
+          }
     }
 
   if (!close_mixed (&mixed))
@@ -311,123 +311,123 @@ transform_po_source (RECODE_TASK task)
     {
       int character = get_byte (&mixed.subtask);
       while (character != EOF)
-	switch (character)
-	  {
-	  case '#':
-	    /* Copy a comment, recoding only those written by translators.  */
+        switch (character)
+          {
+          case '#':
+            /* Copy a comment, recoding only those written by translators.  */
 
-	    put_byte ('#', &mixed.subtask);
-	    character = get_byte (&mixed.subtask);
-	    if (character == EOF)
-	      break;
-	    recode = character == ' ' || character == '\t';
+            put_byte ('#', &mixed.subtask);
+            character = get_byte (&mixed.subtask);
+            if (character == EOF)
+              break;
+            recode = character == ' ' || character == '\t';
 
-	    if (recode)
-	      start_accumulation (&mixed);
+            if (recode)
+              start_accumulation (&mixed);
 
-	    while (character != '\n' && character != EOF)
-	      {
-		put_byte (character, &mixed.subtask);
-		character = get_byte (&mixed.subtask);
-	      }
+            while (character != '\n' && character != EOF)
+              {
+                put_byte (character, &mixed.subtask);
+                character = get_byte (&mixed.subtask);
+              }
 
-	    if (recode && !recode_accumulated (&mixed))
-	      recode_if_nogo (RECODE_SYSTEM_ERROR, &mixed.subtask);
+            if (recode && !recode_accumulated (&mixed))
+              recode_if_nogo (RECODE_SYSTEM_ERROR, &mixed.subtask);
 
-	    if (character == EOF)
-	      break;
-	    put_byte ('\n', &mixed.subtask);
-	    character = get_byte (&mixed.subtask);
-	    break;
+            if (character == EOF)
+              break;
+            put_byte ('\n', &mixed.subtask);
+            character = get_byte (&mixed.subtask);
+            break;
 
-	  case 'm':
-	    /* Attempt to recognise `msgstr'.  */
+          case 'm':
+            /* Attempt to recognise `msgstr'.  */
 
-	    msgstr = false;
+            msgstr = false;
 
-	    put_byte ('m', &mixed.subtask);
-	    character = get_byte (&mixed.subtask);
-	    if (character != 's')
-	      break;
-	    put_byte ('s', &mixed.subtask);
-	    character = get_byte (&mixed.subtask);
-	    if (character != 'g')
-	      break;
-	    put_byte ('g', &mixed.subtask);
-	    character = get_byte (&mixed.subtask);
-	    if (character != 's')
-	      break;
-	    put_byte ('s', &mixed.subtask);
-	    character = get_byte (&mixed.subtask);
-	    if (character != 't')
-	      break;
-	    put_byte ('t', &mixed.subtask);
-	    character = get_byte (&mixed.subtask);
-	    if (character != 'r')
-	      break;
-	    put_byte ('r', &mixed.subtask);
-	    character = get_byte (&mixed.subtask);
+            put_byte ('m', &mixed.subtask);
+            character = get_byte (&mixed.subtask);
+            if (character != 's')
+              break;
+            put_byte ('s', &mixed.subtask);
+            character = get_byte (&mixed.subtask);
+            if (character != 'g')
+              break;
+            put_byte ('g', &mixed.subtask);
+            character = get_byte (&mixed.subtask);
+            if (character != 's')
+              break;
+            put_byte ('s', &mixed.subtask);
+            character = get_byte (&mixed.subtask);
+            if (character != 't')
+              break;
+            put_byte ('t', &mixed.subtask);
+            character = get_byte (&mixed.subtask);
+            if (character != 'r')
+              break;
+            put_byte ('r', &mixed.subtask);
+            character = get_byte (&mixed.subtask);
 
-	    msgstr = true;
-	    break;
+            msgstr = true;
+            break;
 
-	  case '"':
-	    /* Copy the string, translating only the `msgstr' ones.  */
+          case '"':
+            /* Copy the string, translating only the `msgstr' ones.  */
 
-	    put_byte ('"', &mixed.subtask);
-	    character = get_byte (&mixed.subtask);
-	    recode = msgstr;
+            put_byte ('"', &mixed.subtask);
+            character = get_byte (&mixed.subtask);
+            recode = msgstr;
 
-	    if (recode)
-	      start_accumulation (&mixed);
+            if (recode)
+              start_accumulation (&mixed);
 
-	    while (true)
-	      {
-		if (character == EOF)
-		  {
-		    if (recode)
-		      {
-			recode_accumulated (&mixed);
-			recode_if_nogo (RECODE_SYSTEM_ERROR, &mixed.subtask);
-		      }
-		    break;
-		  }
-		if (character == '"')
-		  break;
+            while (true)
+              {
+                if (character == EOF)
+                  {
+                    if (recode)
+                      {
+                        recode_accumulated (&mixed);
+                        recode_if_nogo (RECODE_SYSTEM_ERROR, &mixed.subtask);
+                      }
+                    break;
+                  }
+                if (character == '"')
+                  break;
 
-		if (character == '\\')
-		  {
-		    put_byte ('\\', &mixed.subtask);
-		    character = get_byte (&mixed.subtask);
-		    if (character == EOF)
-		      {
-			if (recode)
-			  {
-			    recode_accumulated (&mixed);
-			    recode_if_nogo (RECODE_SYSTEM_ERROR, &mixed.subtask);
-			  }
-			break;
-		      }
-		  }
-		put_byte (character, &mixed.subtask);
-		character = get_byte (&mixed.subtask);
-	      }
+                if (character == '\\')
+                  {
+                    put_byte ('\\', &mixed.subtask);
+                    character = get_byte (&mixed.subtask);
+                    if (character == EOF)
+                      {
+                        if (recode)
+                          {
+                            recode_accumulated (&mixed);
+                            recode_if_nogo (RECODE_SYSTEM_ERROR, &mixed.subtask);
+                          }
+                        break;
+                      }
+                  }
+                put_byte (character, &mixed.subtask);
+                character = get_byte (&mixed.subtask);
+              }
 
-	    if (character == EOF)
-	      break;
+            if (character == EOF)
+              break;
 
-	    if (recode && !recode_accumulated (&mixed))
-	      recode_if_nogo (RECODE_SYSTEM_ERROR, &mixed.subtask);
+            if (recode && !recode_accumulated (&mixed))
+              recode_if_nogo (RECODE_SYSTEM_ERROR, &mixed.subtask);
 
-	    put_byte ('"', &mixed.subtask);
-	    character = get_byte (&mixed.subtask);
-	    break;
+            put_byte ('"', &mixed.subtask);
+            character = get_byte (&mixed.subtask);
+            break;
 
-	  default:
-	    put_byte (character, &mixed.subtask);
-	    character = get_byte (&mixed.subtask);
-	    break;
-	  }
+          default:
+            put_byte (character, &mixed.subtask);
+            character = get_byte (&mixed.subtask);
+            break;
+          }
     }
 
   if (!close_mixed (&mixed))

--- a/src/mule.c
+++ b/src/mule.c
@@ -23,14 +23,14 @@
 
 static bool
 transform_latin_mule (RECODE_SUBTASK subtask,
-		      unsigned prefix)
+                      unsigned prefix)
 {
   int character;
 
   while (character = get_byte (subtask), character != EOF)
     {
       if (!IS_ASCII (character))
-	put_byte (prefix, subtask);
+        put_byte (prefix, subtask);
       put_byte (character, subtask);
     }
   SUBTASK_RETURN (subtask);
@@ -38,7 +38,7 @@ transform_latin_mule (RECODE_SUBTASK subtask,
 
 static bool
 transform_mule_latin (RECODE_SUBTASK subtask,
-		      unsigned prefix)
+                      unsigned prefix)
 {
   int character;
 
@@ -47,26 +47,26 @@ transform_mule_latin (RECODE_SUBTASK subtask,
       put_byte (character, subtask);
     else if ((character & BIT_MASK (8)) == prefix)
       {
-	character = get_byte (subtask);
+        character = get_byte (subtask);
 
-	while ((character & BIT_MASK (8)) == prefix)
-	  {
-	    /* This happens in practice, sometimes, that Emacs goes a bit
-	       berzerk and generates strings of prefix characters.  Remove
-	       all succeeding prefixes in a row.  This is irreversible.  */
-	    RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
-	    character = get_byte (subtask);
-	  }
+        while ((character & BIT_MASK (8)) == prefix)
+          {
+            /* This happens in practice, sometimes, that Emacs goes a bit
+               berzerk and generates strings of prefix characters.  Remove
+               all succeeding prefixes in a row.  This is irreversible.  */
+            RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
+            character = get_byte (subtask);
+          }
 
-	if (character == EOF)
-	  {
-	    RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-	    break;
-	  }
+        if (character == EOF)
+          {
+            RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+            break;
+          }
 
-	if (IS_ASCII (character))
-	  RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
-	put_byte (character, subtask);
+        if (IS_ASCII (character))
+          RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
+        put_byte (character, subtask);
       }
     else
       RETURN_IF_NOGO (RECODE_UNTRANSLATABLE, subtask);
@@ -75,17 +75,17 @@ transform_mule_latin (RECODE_SUBTASK subtask,
 }
 
 #define TRANSFORM_LATIN(To_mule, From_mule, Prefix) \
-									\
-  static bool								\
-  To_mule (RECODE_SUBTASK subtask)	\
-  {									\
-    return transform_latin_mule (subtask, Prefix);			\
-  }									\
-									\
-  static bool								\
-  From_mule (RECODE_SUBTASK subtask)	\
-  {									\
-    return transform_mule_latin (subtask, Prefix);			\
+                                                                        \
+  static bool                                                           \
+  To_mule (RECODE_SUBTASK subtask)      \
+  {                                                                     \
+    return transform_latin_mule (subtask, Prefix);                      \
+  }                                                                     \
+                                                                        \
+  static bool                                                           \
+  From_mule (RECODE_SUBTASK subtask)    \
+  {                                                                     \
+    return transform_mule_latin (subtask, Prefix);                      \
   }
 
 TRANSFORM_LATIN (transform_latin1_mule, transform_mule_latin1, 129)
@@ -100,17 +100,17 @@ module_mule (RECODE_OUTER outer)
 {
   return
     declare_single (outer, "ISO-8859-1", "Mule",
-		    outer->quality_byte_to_variable,
-		    NULL, transform_latin1_mule)
+                    outer->quality_byte_to_variable,
+                    NULL, transform_latin1_mule)
     && declare_single (outer, "Mule", "ISO-8859-1",
-		       outer->quality_variable_to_byte,
-		       NULL, transform_mule_latin1)
+                       outer->quality_variable_to_byte,
+                       NULL, transform_mule_latin1)
     && declare_single (outer, "ISO-8859-2", "Mule",
-		       outer->quality_byte_to_variable,
-		       NULL, transform_latin2_mule)
+                       outer->quality_byte_to_variable,
+                       NULL, transform_latin2_mule)
     && declare_single (outer, "Mule", "ISO-8859-2",
-		       outer->quality_variable_to_byte,
-		       NULL, transform_mule_latin2);
+                       outer->quality_variable_to_byte,
+                       NULL, transform_mule_latin2);
 }
 
 void

--- a/src/names.c
+++ b/src/names.c
@@ -26,7 +26,7 @@
 
 /*-------------------------------------------------------------------------.
 | Return the corresponding UCS-2 value in a CHARSET for a given CODE, or a |
-| negative number if this symbol is not defined.			   |
+| negative number if this symbol is not defined.                           |
 `-------------------------------------------------------------------------*/
 
 _GL_ATTRIBUTE_PURE int
@@ -50,8 +50,8 @@ code_to_ucs2 (RECODE_CONST_SYMBOL charset, unsigned code)
 
 static _GL_ATTRIBUTE_PURE bool
 check_restricted (RECODE_CONST_OUTER outer,
-		  RECODE_CONST_SYMBOL before,
-		  RECODE_CONST_SYMBOL after)
+                  RECODE_CONST_SYMBOL before,
+                  RECODE_CONST_SYMBOL after)
 {
   struct recode_known_pair *pair;
   int left;
@@ -62,16 +62,16 @@ check_restricted (RECODE_CONST_OUTER outer,
        pair++)
     {
       /* Reject the charset if the characters in the pair do not exist of
-	 if their respective definition do not match.  */
+         if their respective definition do not match.  */
 
       left = code_to_ucs2 (before, pair->left);
       if (left < 0)
-	return true;
+        return true;
       right = code_to_ucs2 (after, pair->right);
       if (right < 0)
-	return true;
+        return true;
       if (left != right)
-	return true;
+        return true;
     }
 
   /* No restriction found.  */
@@ -151,10 +151,10 @@ name_for_argmatch (RECODE_OUTER outer, const char *name)
     {
       character = *(const unsigned char *) in;
       if ((character >= 'a' && character <= 'z')
-	  || (character >= '0' && character <= '9'))
-	*out++ = character;
+          || (character >= '0' && character <= '9'))
+        *out++ = character;
       else if (character >= 'A' && character <= 'Z')
-	*out++ = character - 'A' + 'a';
+        *out++ = character - 'A' + 'a';
     }
   *out = NUL;
 
@@ -170,13 +170,13 @@ name_for_argmatch (RECODE_OUTER outer, const char *name)
 
 static const char *
 disambiguate_name (RECODE_OUTER outer,
-		   const char *name, enum alias_find_type find_type)
+                   const char *name, enum alias_find_type find_type)
 {
   char *hashname;
   int ordinal;
   const char *result;
 
-  result = NULL;		/* for lint */
+  result = NULL;                /* for lint */
 
   /* Look for a match.  */
 
@@ -185,15 +185,15 @@ disambiguate_name (RECODE_OUTER outer,
       {
       case ALIAS_FIND_AS_CHARSET:
       case ALIAS_FIND_AS_EITHER:
-	name = getenv ("DEFAULT_CHARSET");
-	if (!name || !*name)
+        name = getenv ("DEFAULT_CHARSET");
+        if (!name || !*name)
           name = locale_charset();
-	if (!name || !*name)
+        if (!name || !*name)
           return NULL;
-	break;
+        break;
 
       default:
-	return NULL;
+        return NULL;
       }
 
   hashname = name_for_argmatch (outer, name);
@@ -219,12 +219,12 @@ disambiguate_name (RECODE_OUTER outer,
     case ALIAS_FIND_AS_EITHER:
       ordinal = argmatch (hashname, outer->argmatch_charset_array, NULL, 0);
       if (ordinal >= 0)
-	result = outer->realname_charset_array[ordinal];
+        result = outer->realname_charset_array[ordinal];
       else
-	{
-	  ordinal = argmatch (hashname, outer->argmatch_surface_array, NULL, 0);
-	  result = ordinal < 0 ? NULL : outer->realname_surface_array[ordinal];
-	}
+        {
+          ordinal = argmatch (hashname, outer->argmatch_surface_array, NULL, 0);
+          result = ordinal < 0 ? NULL : outer->realname_surface_array[ordinal];
+        }
       break;
 
     default:
@@ -256,7 +256,7 @@ delete_alias (RECODE_ALIAS alias)
 
 RECODE_ALIAS
 find_alias (RECODE_OUTER outer, const char *name,
-	    enum alias_find_type find_type)
+            enum alias_find_type find_type)
 {
   struct recode_alias lookup;
   RECODE_ALIAS alias;
@@ -278,7 +278,7 @@ find_alias (RECODE_OUTER outer, const char *name,
 
       name = disambiguate_name (outer, name, find_type);
       if (!name)
-	return NULL;
+        return NULL;
     }
 
   /* Search the whole hash bucket and return any match.  */
@@ -349,9 +349,9 @@ declare_alias (RECODE_OUTER outer, const char *name, const char *old_name)
       ((Hash_table *) outer->alias_table, &lookup), alias)
     {
       if (alias->symbol == symbol)
-	return alias;
+        return alias;
       recode_error (outer, _("Charset %s already exists and is not %s"),
-		    name, old_name);
+                    name, old_name);
       return NULL;
     }
 
@@ -378,7 +378,7 @@ declare_alias (RECODE_OUTER outer, const char *name, const char *old_name)
 
 bool
 declare_implied_surface (RECODE_OUTER outer, RECODE_ALIAS alias,
-			 RECODE_CONST_SYMBOL surface)
+                         RECODE_CONST_SYMBOL surface)
 {
   struct recode_surface_list *list;
   struct recode_surface_list *hook;
@@ -393,7 +393,7 @@ declare_implied_surface (RECODE_OUTER outer, RECODE_ALIAS alias,
     {
       list = alias->implied_surfaces;
       while (list->next)
-	list = list->next;
+        list = list->next;
       list->next = hook;
     }
   else
@@ -409,8 +409,8 @@ declare_implied_surface (RECODE_OUTER outer, RECODE_ALIAS alias,
 struct make_argmatch_walk
   {
     RECODE_OUTER outer;
-    unsigned charset_counter;	/* number of acceptable charset names */
-    unsigned surface_counter;	/* number of acceptable surface names */
+    unsigned charset_counter;   /* number of acceptable charset names */
+    unsigned surface_counter;   /* number of acceptable surface names */
   };
 
 static bool
@@ -439,7 +439,7 @@ make_argmatch_walker_2 (void *void_alias, void *void_walk)
       char *string = name_for_argmatch (outer, alias->name);
 
       if (!string)
-	abort ();
+        abort ();
       outer->argmatch_charset_array[walk->charset_counter] = string;
       outer->realname_charset_array[walk->charset_counter] = alias->name;
       walk->charset_counter++;
@@ -449,7 +449,7 @@ make_argmatch_walker_2 (void *void_alias, void *void_walk)
       char *string = name_for_argmatch (outer, alias->name);
 
       if (!string)
-	abort ();
+        abort ();
       outer->argmatch_surface_array[walk->surface_counter] = string;
       outer->realname_surface_array[walk->surface_counter] = alias->name;
       walk->surface_counter++;
@@ -471,9 +471,9 @@ make_argmatch_arrays (RECODE_OUTER outer)
       const char **cursor;
 
       for (cursor = outer->argmatch_charset_array; *cursor; cursor++)
-	free ((char *) *cursor);
+        free ((char *) *cursor);
       for (cursor = outer->argmatch_surface_array; *cursor; cursor++)
-	free ((char *) *cursor);
+        free ((char *) *cursor);
       free (outer->argmatch_charset_array);
     }
 
@@ -483,7 +483,7 @@ make_argmatch_arrays (RECODE_OUTER outer)
   walk.charset_counter = 0;
   walk.surface_counter = 0;
   hash_do_for_each ((Hash_table *) outer->alias_table,
-	 	    make_argmatch_walker_1, &walk);
+                    make_argmatch_walker_1, &walk);
 
   /* Allocate the argmatch and realname arrays, each with a NULL sentinel.  */
 
@@ -491,7 +491,7 @@ make_argmatch_arrays (RECODE_OUTER outer)
     const char **cursor;
 
     if (!ALLOC (cursor, 2*walk.charset_counter + 2*walk.surface_counter + 4,
-		const char *))
+                const char *))
       return false;
 
     outer->argmatch_charset_array = cursor;
@@ -516,7 +516,7 @@ make_argmatch_arrays (RECODE_OUTER outer)
   walk.charset_counter = 0;
   walk.surface_counter = 0;
   hash_do_for_each ((Hash_table *) outer->alias_table,
-	 	    make_argmatch_walker_2, &walk);
+                    make_argmatch_walker_2, &walk);
 
   return true;
 }
@@ -534,58 +534,58 @@ compare_strings (const char *stringA, const char *stringB)
   while (*stringA && *stringB)
     if (*stringA >= '0' && *stringA <= '9')
       if (*stringB >= '0' && *stringB <= '9')
-	{
-	  unsigned valueA = 0;
-	  unsigned valueB = 0;
+        {
+          unsigned valueA = 0;
+          unsigned valueB = 0;
 
-	  while (*stringA >= '0' && *stringA <= '9'
-		 && *stringB >= '0' && *stringB <= '9')
-	    {
-	      valueA = 10 * valueA + *stringA - '0';
-	      valueB = 10 * valueB + *stringB - '0';
-	      if (delayed == 0)
-		delayed = *stringA - *stringB;
-	      stringA++;
-	      stringB++;
-	    }
-	  while (*stringA >= '0' && *stringA <= '9')
-	    {
-	      valueA = 10 * valueA + *stringA - '0';
-	      if (delayed == 0)
-		delayed = 1;
-	      stringA++;
-	    }
-	  while (*stringB >= '0' && *stringB <= '9')
-	    {
-	      valueB = 10 * valueB + *stringB - '0';
-	      if (delayed == 0)
-		delayed = -1;
-	      stringB++;
-	    }
-	  if (valueA - valueB != 0)
-	    return valueA - valueB;
-	}
+          while (*stringA >= '0' && *stringA <= '9'
+                 && *stringB >= '0' && *stringB <= '9')
+            {
+              valueA = 10 * valueA + *stringA - '0';
+              valueB = 10 * valueB + *stringB - '0';
+              if (delayed == 0)
+                delayed = *stringA - *stringB;
+              stringA++;
+              stringB++;
+            }
+          while (*stringA >= '0' && *stringA <= '9')
+            {
+              valueA = 10 * valueA + *stringA - '0';
+              if (delayed == 0)
+                delayed = 1;
+              stringA++;
+            }
+          while (*stringB >= '0' && *stringB <= '9')
+            {
+              valueB = 10 * valueB + *stringB - '0';
+              if (delayed == 0)
+                delayed = -1;
+              stringB++;
+            }
+          if (valueA - valueB != 0)
+            return valueA - valueB;
+        }
       else
-	return -1;
+        return -1;
     else
       if (*stringB >= '0' && *stringB <= '9')
-	return 1;
+        return 1;
       else
-	{
-	  char charA = *stringA;
-	  char charB = *stringB;
+        {
+          char charA = *stringA;
+          char charB = *stringB;
 
-	  if (charA >= 'a' && charA <= 'z')
-	    charA += 'A' - 'a';
-	  if (charB >= 'a' && charB <= 'z')
-	    charB += 'A' - 'a';
-	  if (charA - charB != 0)
-	    return charA - charB;
-	  if (delayed == 0)
-	    delayed = *stringA - *stringB;
-	  stringA++;
-	  stringB++;
-	}
+          if (charA >= 'a' && charA <= 'z')
+            charA += 'A' - 'a';
+          if (charB >= 'a' && charB <= 'z')
+            charB += 'A' - 'a';
+          if (charA - charB != 0)
+            return charA - charB;
+          if (delayed == 0)
+            delayed = *stringA - *stringB;
+          stringA++;
+          stringB++;
+        }
 
   return *stringA ? 1 : *stringB ? -1 : delayed;
 }
@@ -664,14 +664,14 @@ bool
 list_all_symbols (RECODE_OUTER outer, RECODE_CONST_SYMBOL after)
 {
   struct list_symbols_walk walk; /* wanderer's data */
-  RECODE_ALIAS alias;		/* cursor into sorted array */
-  bool list_flag;		/* if the current alias should be listed */
+  RECODE_ALIAS alias;           /* cursor into sorted array */
+  bool list_flag;               /* if the current alias should be listed */
 
   /* Count how many symbols we have.  */
 
   walk.number = 0;
   hash_do_for_each ((Hash_table *) outer->alias_table,
-	 	    list_symbols_walker_1, &walk);
+                    list_symbols_walker_1, &walk);
 
   /* Allocate a structure to hold them.  */
 
@@ -682,12 +682,12 @@ list_all_symbols (RECODE_OUTER outer, RECODE_CONST_SYMBOL after)
 
   walk.number = 0;
   hash_do_for_each ((Hash_table *) outer->alias_table,
-	 	    list_symbols_walker_2, &walk);
+                    list_symbols_walker_2, &walk);
 
   /* Sort it.  */
 
   qsort (walk.array, (size_t) walk.number, sizeof (struct recode_alias),
-	 compare_struct_alias);
+         compare_struct_alias);
 
   /* Print it, one line per symbol, giving the true symbol name first,
      followed by all its alias in lexicographic order.  */
@@ -698,33 +698,33 @@ list_all_symbols (RECODE_OUTER outer, RECODE_CONST_SYMBOL after)
       /* Begin a new line with the true symbol name when it changes.  */
 
       if (alias == walk.array
-	  || alias->symbol->name != (alias - 1)->symbol->name)
-	{
-	  if (list_flag && alias != walk.array)
-	    putchar ('\n');
+          || alias->symbol->name != (alias - 1)->symbol->name)
+        {
+          if (list_flag && alias != walk.array)
+            putchar ('\n');
 
-	  list_flag
-	    = !after || !check_restricted (outer, alias->symbol, after);
+          list_flag
+            = !after || !check_restricted (outer, alias->symbol, after);
 
-	  if (list_flag && alias->symbol->type != RECODE_CHARSET)
-	    putchar ('/');
-	}
+          if (list_flag && alias->symbol->type != RECODE_CHARSET)
+            putchar ('/');
+        }
       else if (list_flag)
-	putchar (' ');
+        putchar (' ');
 
       /* Print a name and its usual surfaces.  */
 
       if (list_flag)
-	{
-	  struct recode_surface_list *cursor;
+        {
+          struct recode_surface_list *cursor;
 
-	  fputs (alias->name, stdout);
-	  for (cursor = alias->implied_surfaces; cursor; cursor = cursor->next)
-	    {
-	      putchar ('/');
-	      fputs (cursor->surface->name, stdout);
-	    }
-	}
+          fputs (alias->name, stdout);
+          for (cursor = alias->implied_surfaces; cursor; cursor = cursor->next)
+            {
+              putchar ('/');
+              fputs (cursor->surface->name, stdout);
+            }
+        }
     }
   if (list_flag)
     putchar ('\n');
@@ -763,7 +763,7 @@ decode_known_pairs (RECODE_OUTER outer, const char *string)
     switch (*cursor)
       {
       default:
-	return false;
+        return false;
 
       case '0':
       case '1':
@@ -775,40 +775,40 @@ decode_known_pairs (RECODE_OUTER outer, const char *string)
       case '7':
       case '8':
       case '9':
-	*pointer = strtoul (cursor, &after, 0);
-	cursor = after;
-	if (*pointer > 255)
-	  return false;
-	break;
+        *pointer = strtoul (cursor, &after, 0);
+        cursor = after;
+        if (*pointer > 255)
+          return false;
+        break;
 
       case ':':
-	cursor++;
-	if (left_value < 0 || pointer != &left_value)
-	  return false;
-	pointer = &right_value;
-	break;
+        cursor++;
+        if (left_value < 0 || pointer != &left_value)
+          return false;
+        pointer = &right_value;
+        break;
 
       case ',':
-	cursor++;
-	if (left_value < 0 || right_value < 0)
-	  return false;
+        cursor++;
+        if (left_value < 0 || right_value < 0)
+          return false;
 
-	outer->pair_restriction[outer->pair_restrictions].left
-	  = (unsigned char) left_value;
-	outer->pair_restriction[outer->pair_restrictions].right
-	  = (unsigned char) right_value;
-	outer->pair_restrictions++;
+        outer->pair_restriction[outer->pair_restrictions].left
+          = (unsigned char) left_value;
+        outer->pair_restriction[outer->pair_restrictions].right
+          = (unsigned char) right_value;
+        outer->pair_restrictions++;
 
-	if (outer->pair_restrictions % 16 == 0)
-	  if (!REALLOC (outer->pair_restriction,
-			outer->pair_restrictions + 16,
-			struct recode_known_pair))
-	    return false;
+        if (outer->pair_restrictions % 16 == 0)
+          if (!REALLOC (outer->pair_restriction,
+                        outer->pair_restrictions + 16,
+                        struct recode_known_pair))
+            return false;
 
-	left_value = -1;
-	right_value = -1;
-	pointer = &left_value;
-	break;
+        left_value = -1;
+        right_value = -1;
+        pointer = &left_value;
+        break;
       }
 
   if (left_value < 0 || right_value < 0)
@@ -830,23 +830,23 @@ decode_known_pairs (RECODE_OUTER outer, const char *string)
 
 bool
 list_concise_charset (RECODE_OUTER outer,
-		      RECODE_CONST_SYMBOL charset,
-		      const enum recode_list_format list_format)
+                      RECODE_CONST_SYMBOL charset,
+                      const enum recode_list_format list_format)
 {
-  unsigned half;		/* half 0, half 1 of the table */
-  const char *format;		/* format string */
-  const char *blanks;		/* white space to replace format string */
-  unsigned counter;		/* code counter */
-  unsigned counter2;		/* code counter */
-  unsigned code;		/* code value */
+  unsigned half;                /* half 0, half 1 of the table */
+  const char *format;           /* format string */
+  const char *blanks;           /* white space to replace format string */
+  unsigned counter;             /* code counter */
+  unsigned counter2;            /* code counter */
+  unsigned code;                /* code value */
 
   /* Ensure we have a strip table to play with.  */
 
   if (charset->data_type != RECODE_STRIP_DATA)
     {
       recode_error (outer,
-		    _("Cannot list `%s', no names available for this charset"),
-		    charset->name);
+                    _("Cannot list `%s', no names available for this charset"),
+                    charset->name);
       return false;
     }
 
@@ -857,7 +857,7 @@ list_concise_charset (RECODE_OUTER outer,
   switch (list_format)
     {
     default:
-      return false;			/* cannot happen */
+      return false;                     /* cannot happen */
 
     case RECODE_NO_FORMAT:
     case RECODE_DECIMAL_FORMAT:
@@ -883,42 +883,42 @@ list_concise_charset (RECODE_OUTER outer,
       /* Skip printing this half if it is empty.  */
 
       for (code = 128 * half; code < 128 * (half + 1); code++)
-	if (code_to_ucs2 (charset, code) >= 0)
-	  break;
+        if (code_to_ucs2 (charset, code) >= 0)
+          break;
       if (code == 128 * (half + 1))
-	continue;
+        continue;
 
       /* Print this half.  */
 
       printf ("\n");
       for (counter = 128 * half; counter < 128 * half + 16; counter++)
-	for (counter2 = 0; counter2 < 128; counter2 += 16)
-	  {
-	    int ucs2;
-	    const char *mnemonic;
+        for (counter2 = 0; counter2 < 128; counter2 += 16)
+          {
+            int ucs2;
+            const char *mnemonic;
 
-	    if (counter2 > 0)
-	      printf ("  ");
+            if (counter2 > 0)
+              printf ("  ");
 
-	    code = counter + counter2;
-	    ucs2 = code_to_ucs2 (charset, code);
-	    mnemonic = ucs2 >= 0 ? ucs2_to_rfc1345 (ucs2) : NULL;
+            code = counter + counter2;
+            ucs2 = code_to_ucs2 (charset, code);
+            mnemonic = ucs2 >= 0 ? ucs2_to_rfc1345 (ucs2) : NULL;
 
-	    /* FIXME: Trailing space elimination is not always effective.  */
+            /* FIXME: Trailing space elimination is not always effective.  */
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
-	    if (ucs2 >= 0)
-	      printf (format, code);
-	    else if (mnemonic || counter2 != 112)
-	      fputs (blanks,  stdout);
+            if (ucs2 >= 0)
+              printf (format, code);
+            else if (mnemonic || counter2 != 112)
+              fputs (blanks,  stdout);
 #pragma GCC diagnostic pop
 
-	    if (mnemonic)
-	      printf (counter2 == 112 ? " %s\n" : " %-3s", mnemonic);
-	    else
-	      printf (counter2 == 112 ? "\n" : "    ");
-	  }
+            if (mnemonic)
+              printf (counter2 == 112 ? " %s\n" : " %-3s", mnemonic);
+            else
+              printf (counter2 == 112 ? "\n" : "    ");
+          }
     }
 
   return true;
@@ -950,13 +950,13 @@ list_full_charset_line (int code, recode_ucs2 ucs2, bool french)
     {
       charname = ucs2_to_french_charname (ucs2);
       if (!charname)
-	charname = ucs2_to_charname (ucs2);
+        charname = ucs2_to_charname (ucs2);
     }
   else
     {
       charname = ucs2_to_charname (ucs2);
       if (!charname)
-	charname = ucs2_to_french_charname (ucs2);
+        charname = ucs2_to_french_charname (ucs2);
     }
 
   if (charname)
@@ -990,80 +990,80 @@ list_full_charset (RECODE_OUTER outer, RECODE_CONST_SYMBOL charset)
     {
     case RECODE_EXPLODE_DATA:
       {
-	const unsigned short *data = (const unsigned short *) charset->data;
-	unsigned code;		/* code counter */
-	unsigned expected;	/* expected value for code counter */
-	bool insert_white;	/* insert a while line before printing */
+        const unsigned short *data = (const unsigned short *) charset->data;
+        unsigned code;          /* code counter */
+        unsigned expected;      /* expected value for code counter */
+        bool insert_white;      /* insert a while line before printing */
 
-	/* Print the long table according to explode data.  */
+        /* Print the long table according to explode data.  */
 
-	printf (_("Dec  Oct Hex   UCS2  Mne  %s\n"), charset->name);
-	insert_white = true;
-	expected = 0;
+        printf (_("Dec  Oct Hex   UCS2  Mne  %s\n"), charset->name);
+        insert_white = true;
+        expected = 0;
 
-	while (*data != DONE)
-	  {
-	    code = *data++;
-	    while (expected < code)
-	      {
-		if (insert_white)
-		  {
-		    putchar ('\n');
-		    insert_white = false;
-		  }
-		list_full_charset_line (expected, expected, french);
-		expected++;
-	      }
-	    if (*data == ELSE || *data == DONE)
-	      insert_white = true;
-	    else
-	      {
-		if (insert_white)
-		  {
-		    putchar ('\n');
-		    insert_white = false;
-		  }
-		list_full_charset_line (code, *data++, french);
-		while (*data != ELSE && *data != DONE)
-		  list_full_charset_line (-1, *data++, french);
-	      }
-	    while (*data != DONE)
-	      data++;
-	    expected = code + 1;
-	    data++;
-	  }
+        while (*data != DONE)
+          {
+            code = *data++;
+            while (expected < code)
+              {
+                if (insert_white)
+                  {
+                    putchar ('\n');
+                    insert_white = false;
+                  }
+                list_full_charset_line (expected, expected, french);
+                expected++;
+              }
+            if (*data == ELSE || *data == DONE)
+              insert_white = true;
+            else
+              {
+                if (insert_white)
+                  {
+                    putchar ('\n');
+                    insert_white = false;
+                  }
+                list_full_charset_line (code, *data++, french);
+                while (*data != ELSE && *data != DONE)
+                  list_full_charset_line (-1, *data++, french);
+              }
+            while (*data != DONE)
+              data++;
+            expected = code + 1;
+            data++;
+          }
       }
       return true;
 
     case RECODE_STRIP_DATA:
       {
-	unsigned code;		/* code counter */
-	int ucs2;		/* UCS-2 translation */
-	bool insert_white;	/* insert a while line before printing */
+        unsigned code;          /* code counter */
+        int ucs2;               /* UCS-2 translation */
+        bool insert_white;      /* insert a while line before printing */
 
-	/* Print the long table according to strip data.  */
+        /* Print the long table according to strip data.  */
 
-	printf (_("Dec  Oct Hex   UCS2  Mne  %s\n"), charset->name);
-	insert_white = true;
+        printf (_("Dec  Oct Hex   UCS2  Mne  %s\n"), charset->name);
+        insert_white = true;
 
-	for (code = 0; code < 256; code++)
-	  if ((ucs2 = code_to_ucs2 (charset, code)), ucs2 >= 0)
-	    {
-	      if (insert_white)
-		{
-		  putchar ('\n');
-		  insert_white = false;
-		}
-	      list_full_charset_line (code, ucs2, french);
-	    }
-	  else
-	    insert_white = true;
+        for (code = 0; code < 256; code++)
+          if ((ucs2 = code_to_ucs2 (charset, code)), ucs2 >= 0)
+            {
+              if (insert_white)
+                {
+                  putchar ('\n');
+                  insert_white = false;
+                }
+              list_full_charset_line (code, ucs2, french);
+            }
+          else
+            insert_white = true;
       }
       return true;
 
     default:
       recode_error (outer, _("Sorry, no names available for `%s'"),
-		    charset->name);
+                    charset->name);
       return false;
     }
 }
@@ -1084,70 +1084,70 @@ find_and_report_subsets (RECODE_OUTER outer)
        charset1 = charset1->next)
     {
       const struct strip_data *table1
-	= (const struct strip_data *) charset1->data;
+        = (const struct strip_data *) charset1->data;
       RECODE_SYMBOL charset2;
 
       if (charset1->ignore || charset1->data_type != RECODE_STRIP_DATA)
-	continue;
+        continue;
 
       for (charset2 = outer->symbol_list;
-	   charset2;
-	   charset2 = charset2->next)
-	{
-	  const struct strip_data *table2
-	    = (const struct strip_data *) charset2->data;
+           charset2;
+           charset2 = charset2->next)
+        {
+          const struct strip_data *table2
+            = (const struct strip_data *) charset2->data;
 
-	  if (charset2->ignore || charset2->data_type != RECODE_STRIP_DATA
-	      || charset2 == charset1)
-	    continue;
+          if (charset2->ignore || charset2->data_type != RECODE_STRIP_DATA
+              || charset2 == charset1)
+            continue;
 
-	  {
-	    bool subset = true;
-	    unsigned distance = 0;
-	    unsigned counter;
-	    unsigned slider;
+          {
+            bool subset = true;
+            unsigned distance = 0;
+            unsigned counter;
+            unsigned slider;
 
-	    for (counter = 0; counter < 256/STRIP_SIZE; counter++)
-	      {
-		const recode_ucs2 *pool1 = table1->pool;
-		const recode_ucs2 *pool2 = table2->pool;
-		const short offset1 = table1->offset[counter];
-		const short offset2 = table2->offset[counter];
+            for (counter = 0; counter < 256/STRIP_SIZE; counter++)
+              {
+                const recode_ucs2 *pool1 = table1->pool;
+                const recode_ucs2 *pool2 = table2->pool;
+                const short offset1 = table1->offset[counter];
+                const short offset2 = table2->offset[counter];
 
-		if (pool1 != pool2 || offset1 != offset2)
-		  for (slider = 0; slider < STRIP_SIZE; slider++)
-		    {
-		      recode_ucs2 value1 = pool1[offset1 + slider];
-		      recode_ucs2 value2 = pool2[offset2 + slider];
+                if (pool1 != pool2 || offset1 != offset2)
+                  for (slider = 0; slider < STRIP_SIZE; slider++)
+                    {
+                      recode_ucs2 value1 = pool1[offset1 + slider];
+                      recode_ucs2 value2 = pool2[offset2 + slider];
 
-		      if (value1 != value2)
-			{
-			  if (value1 == BIT_MASK (16))
-			    distance++;
-			  else
-			    {
-			      subset = false;
-			      break;
-			    }
-			}
-		    }
-		if (!subset)
-		  break;
-	      }
+                      if (value1 != value2)
+                        {
+                          if (value1 == BIT_MASK (16))
+                            distance++;
+                          else
+                            {
+                              subset = false;
+                              break;
+                            }
+                        }
+                    }
+                if (!subset)
+                  break;
+              }
 
-	    if (subset)
-	      {
-		if (distance == 0)
-		  printf ("[  0] %s == %s\n",
-			  charset1->name, charset2->name);
-		else
-		  printf ("[%3u] %s < %s\n", distance,
-			  charset1->name, charset2->name);
+            if (subset)
+              {
+                if (distance == 0)
+                  printf ("[  0] %s == %s\n",
+                          charset1->name, charset2->name);
+                else
+                  printf ("[%3u] %s < %s\n", distance,
+                          charset1->name, charset2->name);
 
-		success = false;
-	      }
-	  }
-	}
+                success = false;
+              }
+          }
+        }
     }
 
   return success;

--- a/src/outer.c
+++ b/src/outer.c
@@ -34,7 +34,7 @@ reversibility (_GL_UNUSED RECODE_SUBTASK subtask, _GL_UNUSED unsigned code)
 
 /*-------------------------------------------------------------------------.
 | Allocate and initialize a new single step, save for the before and after |
-| charsets and quality.							   |
+| charsets and quality.                                                    |
 `-------------------------------------------------------------------------*/
 
 static RECODE_SINGLE
@@ -64,9 +64,9 @@ new_single_step (RECODE_OUTER outer)
 
 RECODE_SINGLE
 declare_single (RECODE_OUTER outer,
-		const char *before_name, const char *after_name,
-		struct recode_quality quality,
-		Recode_init init_routine, Recode_transform transform_routine)
+                const char *before_name, const char *after_name,
+                struct recode_quality quality,
+                Recode_init init_routine, Recode_transform transform_routine)
 {
   RECODE_SINGLE single = new_single_step (outer);
   RECODE_ALIAS before = NULL, after = NULL;
@@ -112,15 +112,15 @@ declare_single (RECODE_OUTER outer,
   if (single->before == outer->data_symbol)
     {
       if (single->after->resurfacer)
-	recode_error (outer, _("Resurfacer set more than once for `%s'"),
-		      after_name);
+        recode_error (outer, _("Resurfacer set more than once for `%s'"),
+                      after_name);
       single->after->resurfacer = single;
     }
   else if (single->after == outer->data_symbol)
     {
       if (single->before->unsurfacer)
-	recode_error (outer, _("Unsurfacer set more than once for `%s'"),
-		      before_name);
+        recode_error (outer, _("Unsurfacer set more than once for `%s'"),
+                      before_name);
       single->before->unsurfacer = single;
     }
 
@@ -150,7 +150,7 @@ declare_iconv (RECODE_OUTER outer, const char *name, const char *iconv_name)
   if (alias = find_alias (outer, name, ALIAS_FIND_AS_EITHER),
       !alias)
     if (alias = find_alias (outer, name, SYMBOL_CREATE_CHARSET),
-	!alias)
+        !alias)
       return false;
   assert(alias->symbol->type == RECODE_CHARSET);
 
@@ -184,7 +184,7 @@ declare_iconv (RECODE_OUTER outer, const char *name, const char *iconv_name)
 
 bool
 declare_explode_data (RECODE_OUTER outer, const unsigned short *data,
-		      const char *name_combined, const char *name_exploded)
+                      const char *name_combined, const char *name_exploded)
 {
   RECODE_ALIAS alias;
   RECODE_SYMBOL charset_combined;
@@ -201,8 +201,8 @@ declare_explode_data (RECODE_OUTER outer, const unsigned short *data,
   if (name_exploded)
     {
       if (alias = find_alias (outer, name_exploded, SYMBOL_CREATE_CHARSET),
-	  !alias)
-	return false;
+          !alias)
+        return false;
 
       charset_exploded = alias->symbol;
       assert(charset_exploded->type == RECODE_CHARSET);
@@ -247,7 +247,7 @@ declare_explode_data (RECODE_OUTER outer, const unsigned short *data,
 
 bool
 declare_strip_data (RECODE_OUTER outer, struct strip_data *data,
-		    const char *name)
+                    const char *name)
 {
   RECODE_ALIAS alias;
   RECODE_SYMBOL charset;
@@ -469,7 +469,7 @@ recode_new_outer (unsigned flags)
     {
       recode_error (NULL, _("Virtual memory exhausted"));
       if (flags & RECODE_AUTO_ABORT_FLAG)
-	exit (1);
+        exit (1);
       return NULL;
     }
 

--- a/src/permut.c
+++ b/src/permut.c
@@ -32,14 +32,14 @@ permute_21 (RECODE_SUBTASK subtask)
     {
       character1 = get_byte (subtask);
       if (character1 == EOF)
-	break;
+        break;
 
       character2 = get_byte (subtask);
       if (character2 == EOF)
-	{
-	  put_byte (character1, subtask);
-	  break;
-	}
+        {
+          put_byte (character1, subtask);
+          break;
+        }
 
       put_byte (character2, subtask);
       put_byte (character1, subtask);
@@ -60,31 +60,31 @@ permute_4321 (RECODE_SUBTASK subtask)
     {
       character1 = get_byte (subtask);
       if (character1 == EOF)
-	break;
+        break;
 
       character2 = get_byte (subtask);
       if (character2 == EOF)
-	{
-	  put_byte (character1, subtask);
-	  break;
-	}
+        {
+          put_byte (character1, subtask);
+          break;
+        }
 
       character3 = get_byte (subtask);
       if (character3 == EOF)
-	{
-	  put_byte (character2, subtask);
-	  put_byte (character1, subtask);
-	  break;
-	}
+        {
+          put_byte (character2, subtask);
+          put_byte (character1, subtask);
+          break;
+        }
 
       character4 = get_byte (subtask);
       if (character4 == EOF)
-	{
-	  put_byte (character3, subtask);
-	  put_byte (character2, subtask);
-	  put_byte (character1, subtask);
-	  break;
-	}
+        {
+          put_byte (character3, subtask);
+          put_byte (character2, subtask);
+          put_byte (character1, subtask);
+          break;
+        }
 
       put_byte (character4, subtask);
       put_byte (character3, subtask);
@@ -100,17 +100,17 @@ module_permutations (RECODE_OUTER outer)
 {
   return
     declare_single (outer, "data", "21-Permutation",
-		    outer->quality_variable_to_variable,
-		    NULL, permute_21)
+                    outer->quality_variable_to_variable,
+                    NULL, permute_21)
     && declare_single (outer, "21-Permutation", "data",
-		       outer->quality_variable_to_variable,
-		       NULL, permute_21)
+                       outer->quality_variable_to_variable,
+                       NULL, permute_21)
     && declare_single (outer, "data", "4321-Permutation",
-		       outer->quality_variable_to_variable,
-		       NULL, permute_4321)
+                       outer->quality_variable_to_variable,
+                       NULL, permute_4321)
     && declare_single (outer, "4321-Permutation", "data",
-		       outer->quality_variable_to_variable,
-		       NULL, permute_4321)
+                       outer->quality_variable_to_variable,
+                       NULL, permute_4321)
     && declare_alias (outer, "swabytes", "21-Permutation");
 }
 

--- a/src/quoted.c
+++ b/src/quoted.c
@@ -54,14 +54,14 @@ static const char safe_char_bitnet[1 << 7] =
 };
 
 #define PUT_QUOTED(Character) \
-  do {								\
-    unsigned nibble;							\
-								\
-    put_byte ('=', subtask);					\
-    nibble = BIT_MASK (4) & (Character) >> 4;			\
-    put_byte ((nibble < 10 ? '0' : 'A' - 10) + nibble, subtask);	\
-    nibble = BIT_MASK (4) & (Character);				\
-    put_byte ((nibble < 10 ? '0' : 'A' - 10) + nibble, subtask);	\
+  do {                                                          \
+    unsigned nibble;                                                    \
+                                                                \
+    put_byte ('=', subtask);                                    \
+    nibble = BIT_MASK (4) & (Character) >> 4;                   \
+    put_byte ((nibble < 10 ? '0' : 'A' - 10) + nibble, subtask);        \
+    nibble = BIT_MASK (4) & (Character);                                \
+    put_byte ((nibble < 10 ? '0' : 'A' - 10) + nibble, subtask);        \
   } while (false)
 
 static bool
@@ -81,128 +81,128 @@ transform_data_quoted_printable (RECODE_SUBTASK subtask)
       /* Case of a safe character.  */
 
       if (available > 1)
-	{
-	  put_byte (character, subtask);
-	  available--;
-	  character = get_byte (subtask);
-	}
+        {
+          put_byte (character, subtask);
+          available--;
+          character = get_byte (subtask);
+        }
       else
-	{
-	  next_character = get_byte (subtask);
-	  if (next_character == '\n')
-	    {
-	      put_byte (character, subtask);
-	      put_byte ('\n', subtask);
-	      available = MIME_LINE_LENGTH;
-	      character = get_byte (subtask);
-	    }
-	  else if (next_character == EOF)
-	    {
-	      put_byte (character, subtask);
-	      available--;
-	      character = EOF;
-	    }
-	  else
-	    {
-	      put_byte ('=', subtask);
-	      put_byte ('\n', subtask);
-	      put_byte (character, subtask);
-	      available = MIME_LINE_LENGTH - 1;
-	      character = next_character;
-	    }
-	}
+        {
+          next_character = get_byte (subtask);
+          if (next_character == '\n')
+            {
+              put_byte (character, subtask);
+              put_byte ('\n', subtask);
+              available = MIME_LINE_LENGTH;
+              character = get_byte (subtask);
+            }
+          else if (next_character == EOF)
+            {
+              put_byte (character, subtask);
+              available--;
+              character = EOF;
+            }
+          else
+            {
+              put_byte ('=', subtask);
+              put_byte ('\n', subtask);
+              put_byte (character, subtask);
+              available = MIME_LINE_LENGTH - 1;
+              character = next_character;
+            }
+        }
     else
       switch (character)
-	{
-	case '\n':
+        {
+        case '\n':
 
-	  /* Case of a newline.  */
+          /* Case of a newline.  */
 
-	  put_byte ('\n', subtask);
-	  available = MIME_LINE_LENGTH;
-	  character = get_byte (subtask);
-	  break;
+          put_byte ('\n', subtask);
+          available = MIME_LINE_LENGTH;
+          character = get_byte (subtask);
+          break;
 
-	case '\t':
-	case ' ':
+        case '\t':
+        case ' ':
 
-	  /* Case of a space character.  */
+          /* Case of a space character.  */
 
-	  next_character = get_byte (subtask);
-	  if (next_character == '\n')
-	    {
-	      if (available < 3)
-		{
-		  put_byte ('=', subtask);
-		  put_byte ('\n', subtask);
-		}
-	      PUT_QUOTED (character);
-	      put_byte ('\n', subtask);
-	      available = MIME_LINE_LENGTH;
-	      character = get_byte (subtask);
-	    }
-	  else if (next_character == EOF)
-	    {
-	      if (available < 3)
-		{
-		  put_byte ('=', subtask);
-		  put_byte ('\n', subtask);
-		  available = MIME_LINE_LENGTH;
-		}
-	      PUT_QUOTED (character);
-	      available--;
-	      character = EOF;
-	    }
-	  else
-	    {
-	      if (available == 1)
-		{
-		  put_byte ('=', subtask);
-		  put_byte ('\n', subtask);
-		  available = MIME_LINE_LENGTH;
-		}
-	      put_byte (character, subtask);
-	      available--;
-	      character = next_character;
-	    }
-	  break;
+          next_character = get_byte (subtask);
+          if (next_character == '\n')
+            {
+              if (available < 3)
+                {
+                  put_byte ('=', subtask);
+                  put_byte ('\n', subtask);
+                }
+              PUT_QUOTED (character);
+              put_byte ('\n', subtask);
+              available = MIME_LINE_LENGTH;
+              character = get_byte (subtask);
+            }
+          else if (next_character == EOF)
+            {
+              if (available < 3)
+                {
+                  put_byte ('=', subtask);
+                  put_byte ('\n', subtask);
+                  available = MIME_LINE_LENGTH;
+                }
+              PUT_QUOTED (character);
+              available--;
+              character = EOF;
+            }
+          else
+            {
+              if (available == 1)
+                {
+                  put_byte ('=', subtask);
+                  put_byte ('\n', subtask);
+                  available = MIME_LINE_LENGTH;
+                }
+              put_byte (character, subtask);
+              available--;
+              character = next_character;
+            }
+          break;
 
-	default:
+        default:
 
-	  /* Case of an inconditional quotable character.  */
+          /* Case of an inconditional quotable character.  */
 
-	  if (available > 3)
-	    {
-	      PUT_QUOTED (character);
-	      available -= 3;
-	      character = get_byte (subtask);
-	    }
-	  else
-	    {
-	      next_character = get_byte (subtask);
-	      if (available == 3 && next_character == '\n')
-		{
-		  PUT_QUOTED (character);
-		  put_byte ('\n', subtask);
-		  available = MIME_LINE_LENGTH;
-		  character = get_byte (subtask);
-		}
-	      else if (next_character == EOF)
-		{
-		  PUT_QUOTED (character);
-		  available--;
-		  character = EOF;
-		}
-	      else
-		{
-		  put_byte ('=', subtask);
-		  put_byte ('\n', subtask);
-		  PUT_QUOTED (character);
-		  available = MIME_LINE_LENGTH - 3;
-		  character = next_character;
-		}
-	    }
-	}
+          if (available > 3)
+            {
+              PUT_QUOTED (character);
+              available -= 3;
+              character = get_byte (subtask);
+            }
+          else
+            {
+              next_character = get_byte (subtask);
+              if (available == 3 && next_character == '\n')
+                {
+                  PUT_QUOTED (character);
+                  put_byte ('\n', subtask);
+                  available = MIME_LINE_LENGTH;
+                  character = get_byte (subtask);
+                }
+              else if (next_character == EOF)
+                {
+                  PUT_QUOTED (character);
+                  available--;
+                  character = EOF;
+                }
+              else
+                {
+                  put_byte ('=', subtask);
+                  put_byte ('\n', subtask);
+                  PUT_QUOTED (character);
+                  available = MIME_LINE_LENGTH - 3;
+                  character = next_character;
+                }
+            }
+        }
 
   if (available != MIME_LINE_LENGTH)
     {
@@ -229,115 +229,115 @@ transform_quoted_printable_data (RECODE_SUBTASK subtask)
     switch (character)
       {
       case '\n':
-	/* Process hard line break.  */
+        /* Process hard line break.  */
 
-	if (counter > MIME_LINE_LENGTH)
-	  RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
-	counter = 0;
-	put_byte ('\n', subtask);
-	character = get_byte (subtask);
-	break;
+        if (counter > MIME_LINE_LENGTH)
+          RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
+        counter = 0;
+        put_byte ('\n', subtask);
+        character = get_byte (subtask);
+        break;
 
       case ' ':
       case '\t':
-	/* Process white space.  */
+        /* Process white space.  */
 
-	cursor = buffer;
-	while (character == ' ' || character == '\t')
-	  {
-	    if (cursor == buffer + MIME_LINE_LENGTH)
-	      {
-		RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-		for (cursor = buffer;
-		     cursor < buffer + MIME_LINE_LENGTH;
-		     cursor++)
-		  put_byte (*cursor, subtask);
-	      }
-	    counter++;
-	    *cursor++ = character;
-	    character = get_byte (subtask);
-	  }
-	if (character == '\n' || character == EOF)
-	  {
-	    RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
-	    counter = 0;
-	    break;
-	  }
-	*cursor = '\0';
-	for (cursor = buffer; *cursor; cursor++)
-	  put_byte (*cursor, subtask);
-	break;
+        cursor = buffer;
+        while (character == ' ' || character == '\t')
+          {
+            if (cursor == buffer + MIME_LINE_LENGTH)
+              {
+                RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+                for (cursor = buffer;
+                     cursor < buffer + MIME_LINE_LENGTH;
+                     cursor++)
+                  put_byte (*cursor, subtask);
+              }
+            counter++;
+            *cursor++ = character;
+            character = get_byte (subtask);
+          }
+        if (character == '\n' || character == EOF)
+          {
+            RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
+            counter = 0;
+            break;
+          }
+        *cursor = '\0';
+        for (cursor = buffer; *cursor; cursor++)
+          put_byte (*cursor, subtask);
+        break;
 
       case '=':
-	counter++;
-	character = get_byte (subtask);
-	if (character == ' ' || character == '\t' || character == '\n')
-	  {
-	    /* Process soft line break.  */
+        counter++;
+        character = get_byte (subtask);
+        if (character == ' ' || character == '\t' || character == '\n')
+          {
+            /* Process soft line break.  */
 
-	    if (character == ' ' || character == '\t')
-	      {
-		RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
-		while (character == ' ' || character == '\t')
-		  {
-		    counter++;
-		    character = get_byte (subtask);
-		  }
-	      }
-	    if (character != '\n')
-	      {
-		RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-		break;
-	      }
-	    if (counter > MIME_LINE_LENGTH)
-	      RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
-	    counter = 0;
-	    character = get_byte (subtask);
-	    break;
-	  }
+            if (character == ' ' || character == '\t')
+              {
+                RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
+                while (character == ' ' || character == '\t')
+                  {
+                    counter++;
+                    character = get_byte (subtask);
+                  }
+              }
+            if (character != '\n')
+              {
+                RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+                break;
+              }
+            if (counter > MIME_LINE_LENGTH)
+              RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
+            counter = 0;
+            character = get_byte (subtask);
+            break;
+          }
 
-	/* Process quoted value.  */
+        /* Process quoted value.  */
 
-	counter++;
-	if (character >= '0' && character <= '9')
-	  value = (character - '0') << 4;
-	else if (character >= 'a' && character <= 'f')
-	  value = (character - 'a' + 10) << 4;
-	else if (character >= 'A' && character <= 'F')
-	  value = (character - 'A' + 10) << 4;
-	else
-	  {
-	    RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-	    break;
-	  }
-	character = get_byte (subtask);
-	counter++;
-	if (character >= '0' && character <= '9')
-	  value |= character - '0';
-	else if (character >= 'a' && character <= 'f')
-	  value |= character - 'a' + 10;
-	else if (character >= 'A' && character <= 'F')
-	  value |= character - 'A' + 10;
-	else
-	  {
-	    RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-	    break;
-	  }
-	if (!(value & (1 << 7)) && safe_char[value])
-	  RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
+        counter++;
+        if (character >= '0' && character <= '9')
+          value = (character - '0') << 4;
+        else if (character >= 'a' && character <= 'f')
+          value = (character - 'a' + 10) << 4;
+        else if (character >= 'A' && character <= 'F')
+          value = (character - 'A' + 10) << 4;
+        else
+          {
+            RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+            break;
+          }
+        character = get_byte (subtask);
+        counter++;
+        if (character >= '0' && character <= '9')
+          value |= character - '0';
+        else if (character >= 'a' && character <= 'f')
+          value |= character - 'a' + 10;
+        else if (character >= 'A' && character <= 'F')
+          value |= character - 'A' + 10;
+        else
+          {
+            RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+            break;
+          }
+        if (!(value & (1 << 7)) && safe_char[value])
+          RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
 
-	put_byte (value, subtask);
-	character = get_byte (subtask);
-	break;
+        put_byte (value, subtask);
+        character = get_byte (subtask);
+        break;
 
       default:
-	/* Process safe character.  */
+        /* Process safe character.  */
 
-	counter++;
-	if (character & (1 << 7) || !safe_char[character])
-	  RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-	put_byte (character, subtask);
-	character = get_byte (subtask);
+        counter++;
+        if (character & (1 << 7) || !safe_char[character])
+          RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+        put_byte (character, subtask);
+        character = get_byte (subtask);
       }
 
   if (counter != 0)
@@ -352,11 +352,11 @@ module_quoted_printable (RECODE_OUTER outer)
 {
   return
     declare_single (outer, "data", "Quoted-Printable",
-		    outer->quality_variable_to_variable,
-		    NULL, transform_data_quoted_printable)
+                    outer->quality_variable_to_variable,
+                    NULL, transform_data_quoted_printable)
     && declare_single (outer, "Quoted-Printable", "data",
-		       outer->quality_variable_to_variable,
-		       NULL, transform_quoted_printable_data)
+                       outer->quality_variable_to_variable,
+                       NULL, transform_quoted_printable_data)
     && declare_alias (outer, "quote-printable", "Quoted-Printable")
     && declare_alias (outer, "QP", "Quoted-Printable");
 }

--- a/src/recode.c
+++ b/src/recode.c
@@ -105,22 +105,22 @@ invert_table (RECODE_OUTER outer, const unsigned char *table)
   for (counter = 0; counter < 256; counter++)
     {
       if (flag[table[counter]])
-	{
-	  recode_error (outer, _("Codes %3d and %3u both recode to %3d"),
-			result[table[counter]], counter, table[counter]);
-	  table_error = true;
-	}
+        {
+          recode_error (outer, _("Codes %3d and %3u both recode to %3d"),
+                        result[table[counter]], counter, table[counter]);
+          table_error = true;
+        }
       else
-	{
-	  result[table[counter]] = counter;
-	  flag[table[counter]] = 1;
-	}
+        {
+          result[table[counter]] = counter;
+          flag[table[counter]] = 1;
+        }
     }
   if (table_error)
     {
       for (counter = 0; counter < 256; counter++)
-	if (!flag[counter])
-	  recode_error (outer, _("No character recodes to %3u"), counter);
+        if (!flag[counter])
+          recode_error (outer, _("No character recodes to %3u"), counter);
       recode_error (outer, _("Cannot invert given one-to-one table"));
     }
   return result;
@@ -137,8 +137,8 @@ invert_table (RECODE_OUTER outer, const unsigned char *table)
 
 bool
 complete_pairs (RECODE_OUTER outer, RECODE_STEP step,
-		const struct recode_known_pair *known_pairs,
-		unsigned number_of_pairs, bool first_half_implied, bool reverse)
+                const struct recode_known_pair *known_pairs,
+                unsigned number_of_pairs, bool first_half_implied, bool reverse)
 {
   unsigned char left_flag[256];
   unsigned char right_flag[256];
@@ -174,36 +174,36 @@ complete_pairs (RECODE_OUTER outer, RECODE_STEP step,
       /* Set one known correspondence.  */
 
       if (left_flag[left])
-	{
-	  if (!table_error)
-	    {
-	      recode_error (outer, _("Following diagnostics for `%s' to `%s'"),
-			    step->before->name, step->after->name);
-	      table_error = true;
-	    }
-	  recode_error (outer,
-			_("Pair no. %u: <%3d, %3d> conflicts with <%3d, %3d>"),
-			counter, left, right, left, left_table[left]);
-	}
+        {
+          if (!table_error)
+            {
+              recode_error (outer, _("Following diagnostics for `%s' to `%s'"),
+                            step->before->name, step->after->name);
+              table_error = true;
+            }
+          recode_error (outer,
+                        _("Pair no. %u: <%3d, %3d> conflicts with <%3d, %3d>"),
+                        counter, left, right, left, left_table[left]);
+        }
       else if (right_flag[right])
-	{
-	  if (!table_error)
-	    {
-	      recode_error (outer, _("Following diagnostics for `%s' to `%s'"),
-			   step->before->name, step->after->name);
-	      table_error = true;
-	    }
-	  recode_error (outer,
-			_("Pair no. %u: <%3d, %3d> conflicts with <%3d, %3d>"),
-			counter, left, right, right_table[right], right);
-	}
+        {
+          if (!table_error)
+            {
+              recode_error (outer, _("Following diagnostics for `%s' to `%s'"),
+                           step->before->name, step->after->name);
+              table_error = true;
+            }
+          recode_error (outer,
+                        _("Pair no. %u: <%3d, %3d> conflicts with <%3d, %3d>"),
+                        counter, left, right, right_table[right], right);
+        }
       else
-	{
-	  left_flag[left] = 1;
-	  left_table[left] = right;
-	  right_flag[right] = 1;
-	  right_table[right] = left;
-	}
+        {
+          left_flag[left] = 1;
+          left_table[left] = right;
+          right_flag[right] = 1;
+          right_table[right] = left;
+        }
     }
 
   /* Set all the implied correspondances.  */
@@ -211,41 +211,41 @@ complete_pairs (RECODE_OUTER outer, RECODE_STEP step,
   if (first_half_implied)
     for (counter = 0; counter < 128; counter++)
       if (!left_flag[counter] && !right_flag[counter])
-	{
-	  left_flag[counter] = 1;
-	  left_table[counter] = counter;
-	  right_flag[counter] = 1;
-	  right_table[counter] = counter;
-	}
+        {
+          left_flag[counter] = 1;
+          left_table[counter] = counter;
+          right_flag[counter] = 1;
+          right_table[counter] = counter;
+        }
 
   if (step->fallback_routine == reversibility)
     {
       /* If the recoding is not strict, compute a reversible one to one
-	 table.  */
+         table.  */
 
       if (table_error)
-	recode_error (outer,
-		      _("Cannot complete table from set of known pairs"));
+        recode_error (outer,
+                      _("Cannot complete table from set of known pairs"));
 
       /* Close the table with small permutation cycles.  */
 
       for (counter = 0; counter < 256; counter++)
-	if (!right_flag[counter])
-	  {
-	    search = counter;
-	    while (left_flag[search])
-	      search = left_table[search];
-	    left_flag[search] = 1;
-	    left_table[search] = counter;
-	    right_flag[counter] = 1;
-	    right_table[counter] = search;
-	  }
+        if (!right_flag[counter])
+          {
+            search = counter;
+            while (left_flag[search])
+              search = left_table[search];
+            left_flag[search] = 1;
+            left_table[search] = counter;
+            right_flag[counter] = 1;
+            right_table[counter] = search;
+          }
 
       /* Save a copy of the proper table.  */
 
       step->transform_routine = transform_byte_to_byte;
       if (!ALLOC (table, 256, unsigned char))
-	return false;
+        return false;
       memcpy (table, reverse ? right_table : left_table, 256);
       step->step_type = RECODE_BYTE_TO_BYTE;
       step->step_table = table;
@@ -258,43 +258,43 @@ complete_pairs (RECODE_OUTER outer, RECODE_STEP step,
   else
     {
       /* If the recoding is strict, prepare a one to many table, each
-	 entry being NULL or a string of a single character.  */
+         entry being NULL or a string of a single character.  */
 
       /* Select the proper table.  */
 
       if (reverse)
-	{
-	  flag = right_flag;
-	  table = right_table;
-	}
+        {
+          flag = right_flag;
+          table = right_table;
+        }
       else
-	{
-	  flag = left_flag;
-	  table = left_table;
-	}
+        {
+          flag = left_flag;
+          table = left_table;
+        }
 
       /* Allocate everything in one blow, so it will be freed likewise.  */
 
       used = 0;
       for (counter = 0; counter < 256; counter++)
-	if (flag[counter])
-	  used++;
+        if (flag[counter])
+          used++;
 
       if (!ALLOC_SIZE (table2, 256 * sizeof (char *) + 2 * used, const char *))
-	return false;
+        return false;
       cursor = (char *) (table2 + 256);
 
       /* Construct the table and the strings in parallel.  */
 
       for (counter = 0; counter < 256; counter++)
-	if (flag[counter])
-	  {
-	    table2[counter] = cursor;
-	    *cursor++ = table[counter];
-	    *cursor++ = NUL;
-	  }
-	else
-	  table2[counter] = NULL;
+        if (flag[counter])
+          {
+            table2[counter] = cursor;
+            *cursor++ = table[counter];
+            *cursor++ = NUL;
+          }
+        else
+          table2[counter] = NULL;
 
       /* Save a one to many recoding table.  */
 
@@ -316,27 +316,27 @@ complete_pairs (RECODE_OUTER outer, RECODE_STEP step,
 bool
 transform_byte_to_ucs2 (RECODE_SUBTASK subtask)
 {
-  int input_char;		/* current character */
-  int output_value;		/* value being output */
+  int input_char;               /* current character */
+  int output_value;             /* value being output */
 
   if (input_char = get_byte (subtask), input_char != EOF)
     {
       if (subtask->task->byte_order_mark)
-	put_ucs2 (BYTE_ORDER_MARK, subtask);
+        put_ucs2 (BYTE_ORDER_MARK, subtask);
 
       while (input_char != EOF)
-	{
-	  output_value = code_to_ucs2 (subtask->step->before, input_char);
-	  if (output_value < 0)
-	    {
-	      RETURN_IF_NOGO (RECODE_UNTRANSLATABLE, subtask);
-	      put_ucs2 (REPLACEMENT_CHARACTER, subtask);
-	    }
-	  else
-	    put_ucs2 (output_value, subtask);
+        {
+          output_value = code_to_ucs2 (subtask->step->before, input_char);
+          if (output_value < 0)
+            {
+              RETURN_IF_NOGO (RECODE_UNTRANSLATABLE, subtask);
+              put_ucs2 (REPLACEMENT_CHARACTER, subtask);
+            }
+          else
+            put_ucs2 (output_value, subtask);
 
-	  input_char = get_byte (subtask);
-	}
+          input_char = get_byte (subtask);
+        }
     }
 
   SUBTASK_RETURN (subtask);
@@ -348,8 +348,8 @@ transform_byte_to_ucs2 (RECODE_SUBTASK subtask)
 
 struct ucs2_to_byte
   {
-    recode_ucs2 code;		/* UCS-2 value */
-    unsigned char byte;		/* corresponding byte */
+    recode_ucs2 code;           /* UCS-2 value */
+    unsigned char byte;         /* corresponding byte */
   };
 
 struct ucs2_to_byte_local
@@ -386,9 +386,9 @@ term_ucs2_to_byte (RECODE_STEP step)
 
 bool
 init_ucs2_to_byte (RECODE_STEP step,
-		   RECODE_CONST_REQUEST request,
-		   RECODE_CONST_OPTION_LIST before_options,
-		   RECODE_CONST_OPTION_LIST after_options)
+                   RECODE_CONST_REQUEST request,
+                   RECODE_CONST_OPTION_LIST before_options,
+                   RECODE_CONST_OPTION_LIST after_options)
 {
   RECODE_OUTER outer = request->outer;
   Hash_table *table;
@@ -399,7 +399,7 @@ init_ucs2_to_byte (RECODE_STEP step,
     return false;
 
   table = hash_initialize (0, NULL,
-			   ucs2_to_byte_hash, ucs2_to_byte_compare, NULL);
+                           ucs2_to_byte_hash, ucs2_to_byte_compare, NULL);
   if (!table)
     return false;
 
@@ -414,11 +414,11 @@ init_ucs2_to_byte (RECODE_STEP step,
       data[counter].code = code_to_ucs2 (step->after, counter);
       data[counter].byte = counter;
       if (!hash_insert (table, data + counter))
-	{
-	  hash_free (table);
-	  free (data);
-	  return false;
-	}
+        {
+          hash_free (table);
+          free (data);
+          return false;
+        }
     }
 
   if (!ALLOC (step->local, 1, struct ucs2_to_byte_local))
@@ -440,16 +440,16 @@ transform_ucs2_to_byte (RECODE_SUBTASK subtask)
   Hash_table *table = ((struct ucs2_to_byte_local *) subtask->step->local)->table;
   struct ucs2_to_byte lookup;
   struct ucs2_to_byte *entry;
-  unsigned input_value;		/* current UCS-2 character */
+  unsigned input_value;         /* current UCS-2 character */
 
   while (get_ucs2 (&input_value, subtask))
     {
       lookup.code = input_value;
       entry = (struct ucs2_to_byte *) hash_lookup (table, &lookup);
       if (entry)
-	put_byte (entry->byte, subtask);
+        put_byte (entry->byte, subtask);
       else
-	RETURN_IF_NOGO (RECODE_UNTRANSLATABLE, subtask);
+        RETURN_IF_NOGO (RECODE_UNTRANSLATABLE, subtask);
     }
 
   SUBTASK_RETURN (subtask);
@@ -463,22 +463,22 @@ transform_ucs2_to_byte (RECODE_SUBTASK subtask)
 
 bool
 recode_format_table (RECODE_REQUEST request,
-		     enum recode_programming_language header_language,
-		     const char *header_name)
+                     enum recode_programming_language header_language,
+                     const char *header_name)
 {
   RECODE_OUTER outer = request->outer;
 
   RECODE_CONST_STEP step; /* step being analysed */
-  unsigned column;		/* column counter */
-  char *name;			/* constructed name */
-  char *cursor;			/* cursor in constructed name */
-  const char *cursor2;		/* cursor to study strings */
-  unsigned counter;		/* general purpose counter */
-  bool underline;		/* previous character was underline */
+  unsigned column;              /* column counter */
+  char *name;                   /* constructed name */
+  char *cursor;                 /* cursor in constructed name */
+  const char *cursor2;          /* cursor to study strings */
+  unsigned counter;             /* general purpose counter */
+  bool underline;               /* previous character was underline */
 
-  const char *start_comment;	/* string starting a comment block */
-  const char *wrap_comment;	/* string separating two comment lines */
-  const char *end_comment;	/* string ending a comment block */
+  const char *start_comment;    /* string starting a comment block */
+  const char *wrap_comment;     /* string separating two comment lines */
+  const char *end_comment;      /* string ending a comment block */
 
   if (request->sequence_length == 0)
     {
@@ -522,9 +522,9 @@ recode_format_table (RECODE_REQUEST request,
   /* Print the header of the header file.  */
 
   printf (_("%sConversion table generated mechanically by %s %s"),
-	  start_comment, PACKAGE, VERSION);
+          start_comment, PACKAGE, VERSION);
   printf (_("%sfor sequence %s.%s"),
-	  wrap_comment, edit_sequence (request, 1), end_comment);
+          wrap_comment, edit_sequence (request, 1), end_comment);
   printf ("\n");
 
   /* Construct the name of the resulting table.  */
@@ -532,7 +532,7 @@ recode_format_table (RECODE_REQUEST request,
   if (header_name)
     {
       if (!ALLOC (name, strlen (header_name) + 1, char))
-	return false;
+        return false;
       strcpy (name, header_name);
     }
   else
@@ -545,15 +545,15 @@ recode_format_table (RECODE_REQUEST request,
   cursor = name;
   for (cursor2 = name; *cursor2; cursor2++)
     if ((*cursor2 >= 'a' && *cursor2 <= 'z')
-	|| (*cursor2 >= 'A' && *cursor2 <= 'Z')
-	|| (*cursor2 >= '0' && *cursor2 <= '9'))
+        || (*cursor2 >= 'A' && *cursor2 <= 'Z')
+        || (*cursor2 >= '0' && *cursor2 <= '9'))
       {
-	if (underline)
-	  {
-	    *cursor++ = '_';
-	    underline = false;
-	  }
-	*cursor++ = *cursor2;
+        if (underline)
+          {
+            *cursor++ = '_';
+            underline = false;
+          }
+        *cursor++ = *cursor2;
       }
     else if (cursor != name)
       underline = true;
@@ -568,46 +568,46 @@ recode_format_table (RECODE_REQUEST request,
       /* Produce a one to one recoding table.  */
 
       switch (header_language)
-	{
-	case RECODE_NO_LANGUAGE:
-	  assert (0);
+        {
+        case RECODE_NO_LANGUAGE:
+          assert (0);
 
-	case RECODE_LANGUAGE_C:
-	  printf ("unsigned char const %s[256] =\n", name);
-	  printf ("  {\n");
-	  break;
+        case RECODE_LANGUAGE_C:
+          printf ("unsigned char const %s[256] =\n", name);
+          printf ("  {\n");
+          break;
 
-	case RECODE_LANGUAGE_PERL:
-	  printf ("@%s =\n", name);
-	  printf ("  (\n");
-	  break;
+        case RECODE_LANGUAGE_PERL:
+          printf ("@%s =\n", name);
+          printf ("  (\n");
+          break;
 
         default:
           break;
-	}
+        }
       for (counter = 0; counter < 256; counter++)
-	{
-	  printf ("%s%3d,", counter % 8 == 0 ? "    " : " ", table[counter]);
-	  if (counter % 8 == 7)
-	    printf ("\t%s%3u - %3u%s",
-		    start_comment, counter - 7, counter, end_comment);
-	}
+        {
+          printf ("%s%3d,", counter % 8 == 0 ? "    " : " ", table[counter]);
+          if (counter % 8 == 7)
+            printf ("\t%s%3u - %3u%s",
+                    start_comment, counter - 7, counter, end_comment);
+        }
       switch (header_language)
-	{
-	case RECODE_NO_LANGUAGE:
-	  assert (0);
+        {
+        case RECODE_NO_LANGUAGE:
+          assert (0);
 
-	case RECODE_LANGUAGE_C:
-	  printf ("  };\n");
-	  break;
+        case RECODE_LANGUAGE_C:
+          printf ("  };\n");
+          break;
 
-	case RECODE_LANGUAGE_PERL:
-	  printf ("  );\n");
-	  break;
+        case RECODE_LANGUAGE_PERL:
+          printf ("  );\n");
+          break;
 
         default:
           break;
-	}
+        }
     }
   else if (step->step_type == RECODE_BYTE_TO_STRING)
     {
@@ -616,132 +616,132 @@ recode_format_table (RECODE_REQUEST request,
       /* Produce a one to many recoding table.  */
 
       switch (header_language)
-	{
-	case RECODE_NO_LANGUAGE:
-	  assert (0);
+        {
+        case RECODE_NO_LANGUAGE:
+          assert (0);
 
-	case RECODE_LANGUAGE_C:
-	  printf ("const char *%s[256] =\n", name);
-	  printf ("  {\n");
-	  break;
+        case RECODE_LANGUAGE_C:
+          printf ("const char *%s[256] =\n", name);
+          printf ("  {\n");
+          break;
 
-	case RECODE_LANGUAGE_PERL:
-	  printf ("@%s =\n", name);
-	  printf ("  (\n");
-	  break;
+        case RECODE_LANGUAGE_PERL:
+          printf ("@%s =\n", name);
+          printf ("  (\n");
+          break;
 
         default:
           break;
-	}
+        }
       for (counter = 0; counter < 256; counter++)
-	{
-	  printf ("    ");
-	  column = 4;
-	  if (table[counter])
-	    {
-	      printf ("\"");
-	      column++;
-	      for (cursor2 = table[counter]; *cursor2; cursor2++)
-		switch (*cursor2)
-		  {
-		  case ' ':
-		    printf (" ");
-		    column++;
-		    break;
+        {
+          printf ("    ");
+          column = 4;
+          if (table[counter])
+            {
+              printf ("\"");
+              column++;
+              for (cursor2 = table[counter]; *cursor2; cursor2++)
+                switch (*cursor2)
+                  {
+                  case ' ':
+                    printf (" ");
+                    column++;
+                    break;
 
-		  case '\b':
-		    printf ("\\b");
-		    column += 2;
-		    break;
+                  case '\b':
+                    printf ("\\b");
+                    column += 2;
+                    break;
 
-		  case '\t':
-		    printf ("\\t");
-		    column += 2;
-		    break;
+                  case '\t':
+                    printf ("\\t");
+                    column += 2;
+                    break;
 
-		  case '\n':
-		    printf ("\\n");
-		    column += 2;
-		    break;
+                  case '\n':
+                    printf ("\\n");
+                    column += 2;
+                    break;
 
-		  case '"':
-		    printf ("\\\"");
-		    column += 2;
-		    break;
+                  case '"':
+                    printf ("\\\"");
+                    column += 2;
+                    break;
 
-		  case '\\':
-		    printf ("\\\\");
-		    column += 2;
-		    break;
+                  case '\\':
+                    printf ("\\\\");
+                    column += 2;
+                    break;
 
-		  case '$':
-		    if (header_language == RECODE_LANGUAGE_PERL)
-		      {
-			printf ("\\$");
-			column += 2;
-			break;
-		      }
+                  case '$':
+                    if (header_language == RECODE_LANGUAGE_PERL)
+                      {
+                        printf ("\\$");
+                        column += 2;
+                        break;
+                      }
                     FALLTHROUGH;
 
-		  default:
-		    if (isprint (*cursor2))
-		      {
-			printf ("%c", *cursor2);
-			column++;
-		      }
-		    else
-		      {
-			printf ("\\%.3o", *(const unsigned char *) cursor2);
-			column += 4;
-		      }
-		  }
-	      printf ("\"");
-	      column++;
-	    }
-	  else
-	    switch (header_language)
-	      {
-	      case RECODE_NO_LANGUAGE:
-		assert (0);
+                  default:
+                    if (isprint (*cursor2))
+                      {
+                        printf ("%c", *cursor2);
+                        column++;
+                      }
+                    else
+                      {
+                        printf ("\\%.3o", *(const unsigned char *) cursor2);
+                        column += 4;
+                      }
+                  }
+              printf ("\"");
+              column++;
+            }
+          else
+            switch (header_language)
+              {
+              case RECODE_NO_LANGUAGE:
+                assert (0);
 
-	      case RECODE_LANGUAGE_C:
-		printf ("0");
-		column++;
-		break;
+              case RECODE_LANGUAGE_C:
+                printf ("0");
+                column++;
+                break;
 
-	      case RECODE_LANGUAGE_PERL:
-		printf ("''");
-		column += 2;
-		break;
+              case RECODE_LANGUAGE_PERL:
+                printf ("''");
+                column += 2;
+                break;
 
               default:
                 break;
-	      }
-	  printf (",");
-	  column++;
-	  while (column < 32)
-	    {
-	      printf ("\t");
-	      column += 8 - column % 8;
-	    }
-	  printf ("%s%3u%s", start_comment, counter, end_comment);
-	}
+              }
+          printf (",");
+          column++;
+          while (column < 32)
+            {
+              printf ("\t");
+              column += 8 - column % 8;
+            }
+          printf ("%s%3u%s", start_comment, counter, end_comment);
+        }
       switch (header_language)
-	{
-	case RECODE_NO_LANGUAGE:
-	  assert (0);
+        {
+        case RECODE_NO_LANGUAGE:
+          assert (0);
 
-	case RECODE_LANGUAGE_C:
-	  printf ("  };\n");
-	  break;
+        case RECODE_LANGUAGE_C:
+          printf ("  };\n");
+          break;
 
-	case RECODE_LANGUAGE_PERL:
-	  printf ("  );\n");
-	  break;
+        case RECODE_LANGUAGE_PERL:
+          printf ("  );\n");
+          break;
 
         default:
           break;
-	}
+        }
     }
   else
     {

--- a/src/recode.h
+++ b/src/recode.h
@@ -18,30 +18,30 @@
 */
 
 /* Published (opaque) typedefs.  */
-typedef struct recode_outer * 			RECODE_OUTER;
-typedef struct recode_request *			RECODE_REQUEST;
-typedef struct recode_task *			RECODE_TASK;
-typedef const struct recode_request *		RECODE_CONST_REQUEST;
-typedef const struct recode_symbol *		RECODE_CONST_SYMBOL;
+typedef struct recode_outer *                   RECODE_OUTER;
+typedef struct recode_request *                 RECODE_REQUEST;
+typedef struct recode_task *                    RECODE_TASK;
+typedef const struct recode_request *           RECODE_CONST_REQUEST;
+typedef const struct recode_symbol *            RECODE_CONST_SYMBOL;
 
 /* Description of list formats.  */
 
 enum recode_list_format
 {
-  RECODE_NO_FORMAT,		/* format not decided yet */
-  RECODE_DECIMAL_FORMAT,	/* concise tabular list using decimal */
-  RECODE_OCTAL_FORMAT,		/* concise tabular list using octal */
-  RECODE_HEXADECIMAL_FORMAT,	/* concise tabular list using hexadecimal */
-  RECODE_FULL_FORMAT		/* full list, one character per line */
+  RECODE_NO_FORMAT,             /* format not decided yet */
+  RECODE_DECIMAL_FORMAT,        /* concise tabular list using decimal */
+  RECODE_OCTAL_FORMAT,          /* concise tabular list using octal */
+  RECODE_HEXADECIMAL_FORMAT,    /* concise tabular list using hexadecimal */
+  RECODE_FULL_FORMAT            /* full list, one character per line */
 };
 
 /* Description of programming languages.  */
 
 enum recode_programming_language
 {
-  RECODE_NO_LANGUAGE,		/* language not decided yet */
-  RECODE_LANGUAGE_C,		/* C (or C++) */
-  RECODE_LANGUAGE_PERL		/* Perl */
+  RECODE_NO_LANGUAGE,           /* language not decided yet */
+  RECODE_LANGUAGE_C,            /* C (or C++) */
+  RECODE_LANGUAGE_PERL          /* Perl */
 };
 
 /* Function prototypes.  */

--- a/src/recodext.h
+++ b/src/recodext.h
@@ -23,18 +23,18 @@
 
 /* Internal typedefs, to supplement those in "recode.h".  */
 
-typedef struct recode_symbol *			RECODE_SYMBOL;
-typedef struct recode_option_list *		RECODE_OPTION_LIST;
-typedef struct recode_single *			RECODE_SINGLE;
-typedef struct recode_step *			RECODE_STEP;
-typedef struct recode_alias *			RECODE_ALIAS;
-typedef struct recode_subtask *			RECODE_SUBTASK;
+typedef struct recode_symbol *                  RECODE_SYMBOL;
+typedef struct recode_option_list *             RECODE_OPTION_LIST;
+typedef struct recode_single *                  RECODE_SINGLE;
+typedef struct recode_step *                    RECODE_STEP;
+typedef struct recode_alias *                   RECODE_ALIAS;
+typedef struct recode_subtask *                 RECODE_SUBTASK;
 
-typedef const struct recode_option_list *	RECODE_CONST_OPTION_LIST;
-typedef const struct recode_outer *		RECODE_CONST_OUTER;
-typedef const struct recode_step *		RECODE_CONST_STEP;
-typedef const struct recode_alias *		RECODE_CONST_ALIAS;
-typedef const struct recode_task *		RECODE_CONST_TASK;
+typedef const struct recode_option_list *       RECODE_CONST_OPTION_LIST;
+typedef const struct recode_outer *             RECODE_CONST_OUTER;
+typedef const struct recode_step *              RECODE_CONST_STEP;
+typedef const struct recode_alias *             RECODE_CONST_ALIAS;
+typedef const struct recode_task *              RECODE_CONST_TASK;
 
 /*--------------------------------------------------------------------------.
 | Return from SUBTASK, with `false' if the failure level has been reached.  |
@@ -49,9 +49,9 @@ typedef const struct recode_task *		RECODE_CONST_TASK;
 `-------------------------------------------------------------------------*/
 
 #define RETURN_IF_NOGO(Error, Subtask) \
-  do {								\
-    if (recode_if_nogo (Error, Subtask))			\
-       SUBTASK_RETURN (Subtask);				\
+  do {                                                          \
+    if (recode_if_nogo (Error, Subtask))                        \
+       SUBTASK_RETURN (Subtask);                                \
   } while (false)
 
 /* Various structure declarations.  */
@@ -64,23 +64,23 @@ typedef const struct recode_task *		RECODE_CONST_TASK;
 
 enum recode_error
   {
-    RECODE_NO_ERROR,		/* no error so far */
-    RECODE_NOT_CANONICAL,	/* input is not exact, but equivalent */
-    RECODE_AMBIGUOUS_OUTPUT,	/* output will be misleading */
-    RECODE_UNTRANSLATABLE,	/* input is getting lost, while valid */
-    RECODE_INVALID_INPUT,	/* input is getting lost, but was invalid */
-    RECODE_SYSTEM_ERROR,	/* system returned input/output failure */
-    RECODE_USER_ERROR,		/* library is being misused */
-    RECODE_INTERNAL_ERROR,	/* programming botch in the library */
-    RECODE_MAXIMUM_ERROR	/* impossible value (should be kept last) */
+    RECODE_NO_ERROR,            /* no error so far */
+    RECODE_NOT_CANONICAL,       /* input is not exact, but equivalent */
+    RECODE_AMBIGUOUS_OUTPUT,    /* output will be misleading */
+    RECODE_UNTRANSLATABLE,      /* input is getting lost, while valid */
+    RECODE_INVALID_INPUT,       /* input is getting lost, but was invalid */
+    RECODE_SYSTEM_ERROR,        /* system returned input/output failure */
+    RECODE_USER_ERROR,          /* library is being misused */
+    RECODE_INTERNAL_ERROR,      /* programming botch in the library */
+    RECODE_MAXIMUM_ERROR        /* impossible value (should be kept last) */
   };
 
 /* Structure for relating alias names to charsets and surfaces.  */
 
 struct recode_alias
   {
-    const char *name;		/* charset, surface or alias name */
-    RECODE_SYMBOL symbol;	/* associated symbol */
+    const char *name;           /* charset, surface or alias name */
+    RECODE_SYMBOL symbol;       /* associated symbol */
     /* If a charset, list of surfaces usually applied by default.  */
     struct recode_surface_list *implied_surfaces;
   };
@@ -89,19 +89,19 @@ struct recode_alias
 
 enum recode_size
   {
-    RECODE_1,			/* roughly one byte per character */
-    RECODE_2,			/* roughly two bytes per character */
-    RECODE_4,			/* roughly four bytes per character */
-    RECODE_N			/* variable number of bytes per character */
+    RECODE_1,                   /* roughly one byte per character */
+    RECODE_2,                   /* roughly two bytes per character */
+    RECODE_4,                   /* roughly four bytes per character */
+    RECODE_N                    /* variable number of bytes per character */
   };
 
 struct recode_quality
   {
     enum recode_size in_size : 3; /* rough byte size of input characters */
     enum recode_size out_size : 3; /* rough byte size of output characters */
-    bool reversible : 1;	/* transformation is known to be reversible */
-    bool slower : 1;		/* transformation is slower than average */
-    bool faster : 1;		/* transformation is faster than average */
+    bool reversible : 1;        /* transformation is known to be reversible */
+    bool slower : 1;            /* transformation is slower than average */
+    bool faster : 1;            /* transformation is faster than average */
   };
 
 /* Main variables of the initialised library.  */
@@ -157,7 +157,7 @@ struct recode_outer
     RECODE_SYMBOL ucs2_charset; /* UCS-2 */
     RECODE_SYMBOL iconv_pivot; /* `iconv' internal UCS */
     RECODE_SYMBOL crlf_surface; /* for IBM PC machines */
-    RECODE_SYMBOL cr_surface;	/* for Macintosh machines */
+    RECODE_SYMBOL cr_surface;   /* for Macintosh machines */
 
     /* Preset qualities, to make step initialisation simpler.  */
     struct recode_quality quality_byte_reversible;
@@ -177,16 +177,16 @@ struct recode_outer
 
 enum recode_symbol_type
   {
-    RECODE_NO_SYMBOL_TYPE,	/* missing value */
-    RECODE_CHARSET,		/* visible in the space of charsets */
-    RECODE_DATA_SURFACE		/* this is a mere data surface */
+    RECODE_NO_SYMBOL_TYPE,      /* missing value */
+    RECODE_CHARSET,             /* visible in the space of charsets */
+    RECODE_DATA_SURFACE         /* this is a mere data surface */
   };
 
 enum recode_data_type
   {
-    RECODE_NO_CHARSET_DATA,	/* the charset_table field is unused */
-    RECODE_STRIP_DATA,		/* pool pointer and array of strips */
-    RECODE_EXPLODE_DATA		/* explode variable length data */
+    RECODE_NO_CHARSET_DATA,     /* the charset_table field is unused */
+    RECODE_STRIP_DATA,          /* pool pointer and array of strips */
+    RECODE_EXPLODE_DATA         /* explode variable length data */
   };
 
 struct recode_symbol
@@ -277,15 +277,15 @@ struct recode_single
 
 enum recode_step_type
   {
-    RECODE_NO_STEP_TABLE,	/* the step_table field is unused */
-    RECODE_BYTE_TO_BYTE,	/* array of 256 bytes */
-    RECODE_BYTE_TO_STRING,	/* array of 256 strings */
-    RECODE_UCS2_TO_BYTE,	/* hash from ucs2 to byte */
-    RECODE_UCS2_TO_STRING,	/* hash from ucs2 to string */
-    RECODE_STRING_TO_UCS2,	/* hash from ucs2 to string, reversed */
-    RECODE_COMBINE_EXPLODE,	/* raw data for combining or exploding */
-    RECODE_COMBINE_STEP,	/* special hash for combining */
-    RECODE_EXPLODE_STEP		/* special hash for exploding */
+    RECODE_NO_STEP_TABLE,       /* the step_table field is unused */
+    RECODE_BYTE_TO_BYTE,        /* array of 256 bytes */
+    RECODE_BYTE_TO_STRING,      /* array of 256 strings */
+    RECODE_UCS2_TO_BYTE,        /* hash from ucs2 to byte */
+    RECODE_UCS2_TO_STRING,      /* hash from ucs2 to string */
+    RECODE_STRING_TO_UCS2,      /* hash from ucs2 to string, reversed */
+    RECODE_COMBINE_EXPLODE,     /* raw data for combining or exploding */
+    RECODE_COMBINE_STEP,        /* special hash for combining */
+    RECODE_EXPLODE_STEP         /* special hash for exploding */
   };
 
 struct recode_step
@@ -368,11 +368,11 @@ struct recode_request
     short sequence_length;
 
     /* Internal variables used while scanning request text.  */
-    char *work_string;		/* buffer space for generated work strings */
-    size_t work_string_length;	/* length of work_string */
+    char *work_string;          /* buffer space for generated work strings */
+    size_t work_string_length;  /* length of work_string */
     size_t work_string_allocated; /* allocated length of work_string */
-    const char *scan_cursor;	/* next character to be seen */
-    char *scanned_string;	/* buffer space to scan strings */
+    const char *scan_cursor;    /* next character to be seen */
+    char *scanned_string;       /* buffer space to scan strings */
   };
 
 /*--------------------------------------------------------------------.
@@ -414,9 +414,9 @@ struct recode_read_write_text
 
 enum recode_swap_input
   {
-    RECODE_SWAP_UNDECIDED,	/* the text has not been read yet */
-    RECODE_SWAP_NO,		/* no need to swap pair of bytes */
-    RECODE_SWAP_YES		/* should swap incoming pair of bytes */
+    RECODE_SWAP_UNDECIDED,      /* the text has not been read yet */
+    RECODE_SWAP_NO,             /* no need to swap pair of bytes */
+    RECODE_SWAP_YES             /* should swap incoming pair of bytes */
   };
 
 /*--------------------------------------------------------------------------.
@@ -490,8 +490,8 @@ struct recode_task
 
 struct recode_known_pair
   {
-    unsigned char left;		/* first character in pair */
-    unsigned char right;	/* second character in pair */
+    unsigned char left;         /* first character in pair */
+    unsigned char right;        /* second character in pair */
   };
 
 /*----------------------.
@@ -525,9 +525,9 @@ struct strip_data
 
 struct ucs2_to_string
   {
-    recode_ucs2 code;		/* UCS-2 value */
-    unsigned short flags;	/* various flags */
-    const char *string;		/* corresponding string */
+    recode_ucs2 code;           /* UCS-2 value */
+    unsigned short flags;       /* various flags */
+    const char *string;         /* corresponding string */
   };
 
 /* Per module declarations.  */
@@ -545,8 +545,8 @@ extern "C" {
   ALLOC_SIZE (Variable, (Count) * sizeof (Type), Type)
 
 #define REALLOC(Variable, Count, Type) \
-  (Variable = (Type *) recode_realloc (outer, Variable,		\
-				       (Count) * sizeof(Type)), \
+  (Variable = (Type *) recode_realloc (outer, Variable,         \
+                                       (Count) * sizeof(Type)), \
    Variable)
 
 void recode_error (RECODE_OUTER, const char *, ...);
@@ -573,11 +573,11 @@ const char *ucs2_to_french_charname (int);
 
 enum alias_find_type
 {
-  SYMBOL_CREATE_CHARSET,	/* charset as given, create as needed */
-  SYMBOL_CREATE_DATA_SURFACE,	/* data surface as given, create as needed */
-  ALIAS_FIND_AS_CHARSET,	/* disambiguate only as a charset */
-  ALIAS_FIND_AS_SURFACE,	/* disambiguate only as a surface */
-  ALIAS_FIND_AS_EITHER		/* disambiguate as a charset or a surface */
+  SYMBOL_CREATE_CHARSET,        /* charset as given, create as needed */
+  SYMBOL_CREATE_DATA_SURFACE,   /* data surface as given, create as needed */
+  ALIAS_FIND_AS_CHARSET,        /* disambiguate only as a charset */
+  ALIAS_FIND_AS_SURFACE,        /* disambiguate only as a surface */
+  ALIAS_FIND_AS_EITHER          /* disambiguate as a charset or a surface */
 };
 
 int code_to_ucs2 (RECODE_CONST_SYMBOL, unsigned);
@@ -701,9 +701,9 @@ bool put_ucs4 (unsigned, RECODE_SUBTASK);
 #ifdef FLEX_SCANNER
 
 # define PUT_NON_DIACRITIC_BYTE(Byte, Subtask) \
-    if (request->diacritics_only)				\
-      ECHO;							\
-    else							\
+    if (request->diacritics_only)                               \
+      ECHO;                                                     \
+    else                                                        \
       put_byte ((Byte), (Subtask))
 
 /* ECHO may not have a (Subtask) argument, because some ECHO without argument
@@ -711,11 +711,11 @@ bool put_ucs4 (unsigned, RECODE_SUBTASK);
    the rule about default copying.  Happily enough, within Flex, Subtask is
    `subtask' quite systematically, so it may be used as a constant, here.  */
 # define ECHO \
-    do {							\
-      const char *cursor = librecode_yytext;			\
-      int counter = librecode_yyleng;				\
-      for (; counter > 0; cursor++, counter--)			\
-	put_byte (*cursor, subtask);				\
+    do {                                                        \
+      const char *cursor = librecode_yytext;                    \
+      int counter = librecode_yyleng;                           \
+      for (; counter > 0; cursor++, counter--)                  \
+        put_byte (*cursor, subtask);                            \
     } while (false)
 
 #endif /* FLEX_SCANNER */

--- a/src/request.c
+++ b/src/request.c
@@ -23,7 +23,7 @@
 /* Quality handling.  */
 
 /*---------------------------------------.
-| Return a string describing a quality.	 |
+| Return a string describing a quality.  |
 `---------------------------------------*/
 
 static const char *
@@ -35,10 +35,10 @@ quality_to_string (struct recode_quality quality)
     return _("reversible");
 
   sprintf (buffer, _("%s to %s"),
-	   (quality.in_size == RECODE_1 ? _("byte")
-	    : quality.in_size == RECODE_2 ? _("ucs2") : _("variable")),
-	   (quality.out_size == RECODE_1 ? _("byte")
-	    : quality.out_size == RECODE_2 ? _("ucs2") : _("variable")));
+           (quality.in_size == RECODE_1 ? _("byte")
+            : quality.in_size == RECODE_2 ? _("ucs2") : _("variable")),
+           (quality.out_size == RECODE_1 ? _("byte")
+            : quality.out_size == RECODE_2 ? _("ucs2") : _("variable")));
   return buffer;
 }
 
@@ -49,7 +49,7 @@ quality_to_string (struct recode_quality quality)
 
 static void
 merge_qualities (struct recode_quality *first,
-		 const struct recode_quality second)
+                 const struct recode_quality second)
 {
   first->out_size = second.out_size;
   first->reversible = first->reversible && second.reversible;
@@ -72,7 +72,7 @@ add_work_character (RECODE_REQUEST request, int character)
 
       request->work_string_allocated += 100;
       new_work_string = (char *)
-	realloc (request->work_string, request->work_string_allocated);
+        realloc (request->work_string, request->work_string_allocated);
       if (new_work_string)
         request->work_string = new_work_string;
       else
@@ -95,7 +95,7 @@ add_work_string (RECODE_REQUEST request, const char *string)
 /*----------------------------------------------------------------------.
 | Generate a string describing the current sequence and return it.      |
 | Include a description of recoding quality only if EDIT_QUALITY is not |
-| zero.								        |
+| zero.                                                                 |
 `----------------------------------------------------------------------*/
 
 char *
@@ -115,83 +115,83 @@ edit_sequence (RECODE_REQUEST request, bool edit_quality)
       RECODE_STEP step = request->sequence_array;
 
       while (step < request->sequence_array + request->sequence_length)
-	{
-	  RECODE_STEP unsurfacer_start = step;
-	  RECODE_STEP unsurfacer_end;
+        {
+          RECODE_STEP unsurfacer_start = step;
+          RECODE_STEP unsurfacer_end;
 
-	  /* Find unsurfacers.  */
+          /* Find unsurfacers.  */
 
-	  while (step < request->sequence_array + request->sequence_length
-		 && step->after == outer->data_symbol)
-	    step++;
-	  unsurfacer_end = step;
+          while (step < request->sequence_array + request->sequence_length
+                 && step->after == outer->data_symbol)
+            step++;
+          unsurfacer_end = step;
 
-	  /* Print BEFORE, sparing it if syntax permits.  */
+          /* Print BEFORE, sparing it if syntax permits.  */
 
-	  if (step != unsurfacer_start
-	      || step == request->sequence_array + request->sequence_length
-	      || step->before != last_charset_printed)
-	    {
-	      if (unsurfacer_start != request->sequence_array)
-		add_work_character (request, ',');
-	      if (step < request->sequence_array + request->sequence_length)
-		{
-		  last_charset_printed = step->before;
-		  add_work_string (request, last_charset_printed->name);
-		}
-	    }
+          if (step != unsurfacer_start
+              || step == request->sequence_array + request->sequence_length
+              || step->before != last_charset_printed)
+            {
+              if (unsurfacer_start != request->sequence_array)
+                add_work_character (request, ',');
+              if (step < request->sequence_array + request->sequence_length)
+                {
+                  last_charset_printed = step->before;
+                  add_work_string (request, last_charset_printed->name);
+                }
+            }
 
-	  /* Print unsurfacers.  */
+          /* Print unsurfacers.  */
 
-	  for (step = unsurfacer_end - 1; step >= unsurfacer_start; step--)
-	    {
-	      add_work_character (request, '/');
-	      add_work_string (request, step->before->name);
-	    }
-	  step = unsurfacer_end;
+          for (step = unsurfacer_end - 1; step >= unsurfacer_start; step--)
+            {
+              add_work_character (request, '/');
+              add_work_string (request, step->before->name);
+            }
+          step = unsurfacer_end;
 
-	  /* Print AFTER.  */
+          /* Print AFTER.  */
 
-	  add_work_string (request, "..");
-	  if (step < request->sequence_array + request->sequence_length
-	      && step->before != outer->data_symbol)
-	    {
-	      last_charset_printed = step->after;
-	      add_work_string (request, last_charset_printed->name);
-	      step++;
-	    }
-	  else
-	    {
-	      last_charset_printed = outer->data_symbol;
-	      add_work_string (request, last_charset_printed->name);
-	    }
+          add_work_string (request, "..");
+          if (step < request->sequence_array + request->sequence_length
+              && step->before != outer->data_symbol)
+            {
+              last_charset_printed = step->after;
+              add_work_string (request, last_charset_printed->name);
+              step++;
+            }
+          else
+            {
+              last_charset_printed = outer->data_symbol;
+              add_work_string (request, last_charset_printed->name);
+            }
 
-	  /* Print resurfacers.  */
+          /* Print resurfacers.  */
 
-	  while (step < request->sequence_array + request->sequence_length
-		 && step->before == outer->data_symbol)
-	    {
-	      add_work_character (request, '/');
-	      last_charset_printed = NULL;
-	      add_work_string (request, step->after->name);
-	      step++;
-	    }
-	}
+          while (step < request->sequence_array + request->sequence_length
+                 && step->before == outer->data_symbol)
+            {
+              add_work_character (request, '/');
+              last_charset_printed = NULL;
+              add_work_string (request, step->after->name);
+              step++;
+            }
+        }
 
       if (edit_quality)
-	{
-	  struct recode_quality quality = outer->quality_byte_reversible;
-	  RECODE_CONST_STEP step2;
+        {
+          struct recode_quality quality = outer->quality_byte_reversible;
+          RECODE_CONST_STEP step2;
 
-	  for (step2 = request->sequence_array;
-	       step2 < request->sequence_array + request->sequence_length;
-	       step2++)
-	    merge_qualities (&quality, step2->quality);
-	  add_work_character (request, ' ');
-	  add_work_character (request, '(');
-	  add_work_string (request, quality_to_string (quality));
-	  add_work_character (request, ')');
-	}
+          for (step2 = request->sequence_array;
+               step2 < request->sequence_array + request->sequence_length;
+               step2++)
+            merge_qualities (&quality, step2->quality);
+          add_work_character (request, ' ');
+          add_work_character (request, '(');
+          add_work_string (request, quality_to_string (quality));
+          add_work_character (request, ')');
+        }
     }
 
   add_work_character (request, NUL);
@@ -207,8 +207,8 @@ edit_sequence (RECODE_REQUEST request, bool edit_quality)
 
 static bool
 add_to_sequence (RECODE_REQUEST request, RECODE_SINGLE single,
-		 RECODE_CONST_OPTION_LIST before_options,
-		 RECODE_CONST_OPTION_LIST after_options)
+                 RECODE_CONST_OPTION_LIST before_options,
+                 RECODE_CONST_OPTION_LIST after_options)
 {
   RECODE_OUTER outer = request->outer;
   RECODE_STEP step;
@@ -218,16 +218,16 @@ add_to_sequence (RECODE_REQUEST request, RECODE_SINGLE single,
       unsigned old_allocated = request->sequence_allocated;
 
       if (request->sequence_allocated == 0)
-	request->sequence_allocated = 16;
+        request->sequence_allocated = 16;
       else
-	request->sequence_allocated *= 2;
+        request->sequence_allocated *= 2;
 
       if (!REALLOC (request->sequence_array, request->sequence_allocated,
-		    struct recode_step))
-	{
-	  recode_error (outer, _("Virtual memory exhausted!"));
-	  return false;
-	}
+                    struct recode_step))
+        {
+          recode_error (outer, _("Virtual memory exhausted!"));
+          return false;
+        }
 
       memset (request->sequence_array + old_allocated, 0,
               (request->sequence_allocated - old_allocated) * sizeof (struct recode_step));
@@ -247,16 +247,16 @@ add_to_sequence (RECODE_REQUEST request, RECODE_SINGLE single,
   if (single->init_routine)
     {
       if (!(*single->init_routine) (step, request,
-				    before_options, after_options))
-	{
-	  recode_error (outer, _("Step initialisation failed"));
-	  return false;
-	}
+                                    before_options, after_options))
+        {
+          recode_error (outer, _("Step initialisation failed"));
+          return false;
+        }
     }
   else if (before_options || after_options)
     {
       recode_error (outer,
-		    _("Step initialisation failed (unprocessed options)"));
+                    _("Step initialisation failed (unprocessed options)"));
       return false;
     }
 
@@ -270,27 +270,27 @@ add_to_sequence (RECODE_REQUEST request, RECODE_SINGLE single,
 `----------------------------------------------------------------------*/
 
 /* Cost corresponding to an impossible conversion.  */
-#define UNREACHABLE	30000
+#define UNREACHABLE     30000
 
 static bool
 find_sequence (RECODE_REQUEST request,
-	       RECODE_CONST_SYMBOL before,
-	       RECODE_CONST_OPTION_LIST before_options,
-	       RECODE_CONST_SYMBOL after,
-	       RECODE_CONST_OPTION_LIST after_options)
+               RECODE_CONST_SYMBOL before,
+               RECODE_CONST_OPTION_LIST before_options,
+               RECODE_CONST_SYMBOL after,
+               RECODE_CONST_OPTION_LIST after_options)
 {
   RECODE_OUTER outer = request->outer;
   struct search
     {
       RECODE_SINGLE single; /* single step aiming towards after */
-      int cost;			/* cost from here through after */
+      int cost;                 /* cost from here through after */
     };
-  struct search *search_array;	/* critical path search tree */
-  struct search *search;	/* item in search_array for charset */
-  RECODE_SINGLE single;	/* cursor in possible single_singles */
-  int cost;			/* cost under consideration */
-  bool modified;		/* if modified since last iteration */
-  RECODE_CONST_SYMBOL charset;	/* charset while reconstructing */
+  struct search *search_array;  /* critical path search tree */
+  struct search *search;        /* item in search_array for charset */
+  RECODE_SINGLE single; /* cursor in possible single_singles */
+  int cost;                     /* cost under consideration */
+  bool modified;                /* if modified since last iteration */
+  RECODE_CONST_SYMBOL charset;  /* charset while reconstructing */
 
   if (!ALLOC (search_array, outer->number_of_symbols, struct search))
     return false;
@@ -312,21 +312,21 @@ find_sequence (RECODE_REQUEST request,
     {
       modified = false;
       for (single = outer->single_list; single; single = single->next)
-	if (!single->before->ignore)
-	  {
-	    cost = search_array[single->after->ordinal].cost;
-	    if (cost != UNREACHABLE)
-	      {
-		cost += single->conversion_cost;
-		search = search_array + single->before->ordinal;
-		if (cost < search->cost)
-		  {
-		    search->single = single;
-		    search->cost = cost;
-		    modified = true;
-		  }
-	      }
-	  }
+        if (!single->before->ignore)
+          {
+            cost = search_array[single->after->ordinal].cost;
+            if (cost != UNREACHABLE)
+              {
+                cost += single->conversion_cost;
+                search = search_array + single->before->ordinal;
+                if (cost < search->cost)
+                  {
+                    search->single = single;
+                    search->cost = cost;
+                    modified = true;
+                  }
+              }
+          }
     }
 
   if (search_array[before->ordinal].cost == UNREACHABLE)
@@ -343,9 +343,9 @@ find_sequence (RECODE_REQUEST request,
     {
       single = search_array[charset->ordinal].single;
       if (!add_to_sequence (request, single,
-			    charset == before ? before_options : NULL,
-			    single->after == after ? after_options : NULL))
-	break;
+                            charset == before ? before_options : NULL,
+                            single->after == after ? after_options : NULL))
+        break;
     }
 
   free (search_array);
@@ -360,7 +360,7 @@ find_sequence (RECODE_REQUEST request,
 
 static enum recode_step_type
 table_type (RECODE_CONST_REQUEST request,
-	    RECODE_CONST_STEP step)
+            RECODE_CONST_STEP step)
 {
   /* When producing source headers, we do not care about algorithms.  */
 
@@ -369,37 +369,37 @@ table_type (RECODE_CONST_REQUEST request,
     switch (step->step_type)
       {
       case RECODE_BYTE_TO_BYTE:
-	if (step->transform_routine != transform_byte_to_byte)
-	  return RECODE_NO_STEP_TABLE;
-	break;
+        if (step->transform_routine != transform_byte_to_byte)
+          return RECODE_NO_STEP_TABLE;
+        break;
 
       case RECODE_BYTE_TO_STRING:
-	if (step->transform_routine != transform_byte_to_variable)
-	  return RECODE_NO_STEP_TABLE;
-	break;
+        if (step->transform_routine != transform_byte_to_variable)
+          return RECODE_NO_STEP_TABLE;
+        break;
 
       default:
-	return RECODE_NO_STEP_TABLE;
+        return RECODE_NO_STEP_TABLE;
       }
 
   return step->step_type;
 }
 
 /*---------------------------------------------------------------.
-| Order two struct item's lexicographically of their key value.	 |
+| Order two struct item's lexicographically of their key value.  |
 `---------------------------------------------------------------*/
 
 struct item
   {
-    unsigned short code;	/* UCS-2 value */
-    unsigned char byte;		/* charset code [0..255] */
+    unsigned short code;        /* UCS-2 value */
+    unsigned char byte;         /* charset code [0..255] */
   };
 
 static int
 compare_struct_item (const void *void_first, const void *void_second)
 {
   return (((const struct item *) void_first)->code
-	  - ((const struct item *) void_second)->code);
+          - ((const struct item *) void_second)->code);
 }
 
 /*------------------------------------------------------------------------.
@@ -414,25 +414,25 @@ complete_double_ucs2_step (RECODE_OUTER outer, RECODE_STEP step)
 {
   struct side
     {
-      RECODE_SYMBOL charset;	/* charset */
-      struct item item[256];	/* array of binding items */
-      size_t number_of_items;	/* number of binding items in array */
+      RECODE_SYMBOL charset;    /* charset */
+      struct item item[256];    /* array of binding items */
+      size_t number_of_items;   /* number of binding items in array */
     };
 
   const struct strip_data *data; /* UCS-2 data table */
-  struct side side_array[2];	/* information for each side */
-  struct side *side;		/* cursor into side_array */
-  bool reversed;		/* if both sides reversed */
-  const recode_ucs2 *pool;	/* pool for fetching UCS-2 characters */
-  unsigned offset;		/* cursor in double table strings */
-  unsigned byte;		/* character code */
-  unsigned row_counter;		/* double table row counter */
-  unsigned position_counter;	/* double table column counter */
-  struct item *item_cursor;	/* cursor in arrays of binding items */
-  struct item *left;		/* left binding items cursor */
-  struct item *left_limit;	/* limit value for left */
-  struct item *right;		/* right binding items cursor */
-  struct item *right_limit;	/* limit value for right */
+  struct side side_array[2];    /* information for each side */
+  struct side *side;            /* cursor into side_array */
+  bool reversed;                /* if both sides reversed */
+  const recode_ucs2 *pool;      /* pool for fetching UCS-2 characters */
+  unsigned offset;              /* cursor in double table strings */
+  unsigned byte;                /* character code */
+  unsigned row_counter;         /* double table row counter */
+  unsigned position_counter;    /* double table column counter */
+  struct item *item_cursor;     /* cursor in arrays of binding items */
+  struct item *left;            /* left binding items cursor */
+  struct item *left_limit;      /* limit value for left */
+  struct item *right;           /* right binding items cursor */
+  struct item *right_limit;     /* limit value for right */
   struct recode_known_pair pair_array[256]; /* obtained pairings */
   struct recode_known_pair *pair_cursor; /* cursor in array of pairings */
 
@@ -465,26 +465,26 @@ complete_double_ucs2_step (RECODE_OUTER outer, RECODE_STEP step)
       byte = 0;
 
       for (row_counter = 0;
-	   row_counter < (256 / STRIP_SIZE);
-	   row_counter++)
-	if (offset = data->offset[row_counter], offset)
-	  for (position_counter = 0;
-	       position_counter < STRIP_SIZE;
-	       position_counter++)
-	    {
-	      unsigned code = pool[offset + position_counter];
+           row_counter < (256 / STRIP_SIZE);
+           row_counter++)
+        if (offset = data->offset[row_counter], offset)
+          for (position_counter = 0;
+               position_counter < STRIP_SIZE;
+               position_counter++)
+            {
+              unsigned code = pool[offset + position_counter];
 
-	      if (code != BIT_MASK (16))
-		{
-		  /* Establish a new binding item.  */
-		  item_cursor->byte = byte;
-		  item_cursor->code = code;
-		  item_cursor++;
-		}
-	      byte++;
-	    }
-	else
-	  byte += STRIP_SIZE;
+              if (code != BIT_MASK (16))
+                {
+                  /* Establish a new binding item.  */
+                  item_cursor->byte = byte;
+                  item_cursor->code = code;
+                  item_cursor++;
+                }
+              byte++;
+            }
+        else
+          byte += STRIP_SIZE;
 
       side->number_of_items = item_cursor - side->item;
     }
@@ -494,9 +494,9 @@ complete_double_ucs2_step (RECODE_OUTER outer, RECODE_STEP step)
      pairing is completed in a time which is linear instead of quadratic.  */
 
   qsort (side_array[0].item, side_array[0].number_of_items,
-	 sizeof (struct item), compare_struct_item);
+         sizeof (struct item), compare_struct_item);
   qsort (side_array[1].item, side_array[1].number_of_items,
-	 sizeof (struct item), compare_struct_item);
+         sizeof (struct item), compare_struct_item);
 
   /* Scan both arrays of binding items simultaneously, saving as pairs
      those codes having the same UCS-2 value.  */
@@ -512,22 +512,22 @@ complete_double_ucs2_step (RECODE_OUTER outer, RECODE_STEP step)
       int value = left->code - right->code;
 
       if (value < 0)
-	left++;
+        left++;
       else if (value > 0)
-	right++;
+        right++;
       else
-	{
-	  pair_cursor->left = (left++)->byte;
-	  pair_cursor->right = (right++)->byte;
-	  pair_cursor++;
-	}
+        {
+          pair_cursor->left = (left++)->byte;
+          pair_cursor->right = (right++)->byte;
+          pair_cursor++;
+        }
     }
 
   /* Complete the recoding table out of this.  */
 
   return
     complete_pairs (outer, step,
-		    pair_array, pair_cursor - pair_array, false, reversed);
+                    pair_array, pair_cursor - pair_array, false, reversed);
 }
 
 static bool
@@ -558,14 +558,14 @@ simplify_sequence (RECODE_REQUEST request)
 {
   RECODE_OUTER outer = request->outer;
 
-  unsigned saved_steps;		/* number of saved steps */
+  unsigned saved_steps;         /* number of saved steps */
   RECODE_STEP in;               /* next studied sequence step */
   RECODE_STEP out;              /* next rewritten sequence step */
   RECODE_STEP limit;            /* last value for IN */
-  unsigned char *accum;		/* byte_to_byte accumulated recoding */
-  const char **string;		/* byte_to_variable recoding */
-  unsigned char temp[256];	/* temporary value for accum array */
-  unsigned counter;		/* all purpose counter */
+  unsigned char *accum;         /* byte_to_byte accumulated recoding */
+  const char **string;          /* byte_to_variable recoding */
+  unsigned char temp[256];      /* temporary value for accum array */
+  unsigned counter;             /* all purpose counter */
 
   /* Tell users what is the goal.  */
 
@@ -582,49 +582,49 @@ simplify_sequence (RECODE_REQUEST request)
 
   while (in < limit)
     if (in < limit - 1
-	&& in[0].before->data_type == RECODE_STRIP_DATA
-	&& in[0].after == outer->ucs2_charset
-	&& in[1].before == outer->ucs2_charset
-	&& in[1].after->data_type == RECODE_STRIP_DATA)
+        && in[0].before->data_type == RECODE_STRIP_DATA
+        && in[0].after == outer->ucs2_charset
+        && in[1].before == outer->ucs2_charset
+        && in[1].after->data_type == RECODE_STRIP_DATA)
       {
         /* Free old steps before overwriting anything.  */
         delete_step (in);
         delete_step (in + 1);
 
-	/* This is a double UCS-2 step.  */
-	out->before = in[0].before;
-	out->after = in[1].after;
-	out->quality = in[0].quality;
-	merge_qualities (&out->quality, in[1].quality);
-	out->transform_routine = transform_byte_to_byte;
+        /* This is a double UCS-2 step.  */
+        out->before = in[0].before;
+        out->after = in[1].after;
+        out->quality = in[0].quality;
+        merge_qualities (&out->quality, in[1].quality);
+        out->transform_routine = transform_byte_to_byte;
 
-	/* Initialize the new single step, so it can be later merged with
-	   others.  */
-	if (!complete_double_ucs2_step (outer, out))
-	  return false;
+        /* Initialize the new single step, so it can be later merged with
+           others.  */
+        if (!complete_double_ucs2_step (outer, out))
+          return false;
 
-	in += 2;
-	saved_steps++;
-	out++;
+        in += 2;
+        saved_steps++;
+        out++;
       }
     else if (in < limit - 1
-	     && in[0].after == outer->iconv_pivot
-	     && in[1].before == outer->iconv_pivot)
+             && in[0].after == outer->iconv_pivot
+             && in[1].before == outer->iconv_pivot)
       {
         /* Free old steps before overwriting anything.  */
         delete_step (in);
         delete_step (in + 1);
 
-	/* This is a double `iconv' step.  */
-	out->before = in[0].before;
-	out->after = in[1].after;
-	out->quality = in[0].quality;
-	merge_qualities (&out->quality, in[1].quality);
-	out->transform_routine = transform_with_iconv;
+        /* This is a double `iconv' step.  */
+        out->before = in[0].before;
+        out->after = in[1].after;
+        out->quality = in[0].quality;
+        merge_qualities (&out->quality, in[1].quality);
+        out->transform_routine = transform_with_iconv;
 
-	in += 2;
-	saved_steps++;
-	out++;
+        in += 2;
+        saved_steps++;
+        out++;
       }
     else if (out != in)
       *out++ = *in++;
@@ -643,75 +643,75 @@ simplify_sequence (RECODE_REQUEST request)
 
   while (in < limit)
     if (in < limit - 1
-	&& table_type (request, in) == RECODE_BYTE_TO_BYTE
-	&& table_type (request, in + 1) != RECODE_NO_STEP_TABLE
+        && table_type (request, in) == RECODE_BYTE_TO_BYTE
+        && table_type (request, in + 1) != RECODE_NO_STEP_TABLE
 
-	/* Initialise a cumulative one-to-one recoding with the identity
-	   permutation.  Just avoid doing it if not enough memory.  */
+        /* Initialise a cumulative one-to-one recoding with the identity
+           permutation.  Just avoid doing it if not enough memory.  */
 
-	&& ALLOC (accum, 256, unsigned char))
+        && ALLOC (accum, 256, unsigned char))
       {
-	memcpy (accum, in->step_table, 256);
-	out->before = in->before;
-	out->after = in->after;
-	out->quality = in->quality;
-	delete_step (in++);
+        memcpy (accum, in->step_table, 256);
+        out->before = in->before;
+        out->after = in->after;
+        out->quality = in->quality;
+        delete_step (in++);
 
-	/* Merge in all consecutive one-to-one recodings.  */
+        /* Merge in all consecutive one-to-one recodings.  */
 
-	while (in < limit
-	       && (table_type (request, in) == RECODE_BYTE_TO_BYTE))
-	  {
-	    const unsigned char *table = (const unsigned char *) in->step_table;
+        while (in < limit
+               && (table_type (request, in) == RECODE_BYTE_TO_BYTE))
+          {
+            const unsigned char *table = (const unsigned char *) in->step_table;
 
-	    for (counter = 0; counter < 256; counter++)
-	      temp[counter] = table[accum[counter]];
-	    memcpy (accum, temp, 256);
+            for (counter = 0; counter < 256; counter++)
+              temp[counter] = table[accum[counter]];
+            memcpy (accum, temp, 256);
 
-	    out->after = in->after;
-	    merge_qualities (&out->quality, in->quality);
-	    delete_step (in++);
-	    saved_steps++;
-	  }
+            out->after = in->after;
+            merge_qualities (&out->quality, in->quality);
+            delete_step (in++);
+            saved_steps++;
+          }
 
-	/* Check for *one* possible one-to-many recoding.  */
+        /* Check for *one* possible one-to-many recoding.  */
 
-	if (in < limit && (table_type (request, in) == RECODE_BYTE_TO_STRING)
+        if (in < limit && (table_type (request, in) == RECODE_BYTE_TO_STRING)
 
-	    /* Merge in the one-to-many recoding.  Just avoid doing it if not
-	       enough memory.  */
+            /* Merge in the one-to-many recoding.  Just avoid doing it if not
+               enough memory.  */
 
-	    && (ALLOC (string, 256, const char *)))
-	  {
-	    const char *const *table = (const char *const *) in->step_table;
+            && (ALLOC (string, 256, const char *)))
+          {
+            const char *const *table = (const char *const *) in->step_table;
 
-	    for (counter = 0; counter < 256; counter++)
-	      string[counter] = table[accum[counter]];
-	    free (accum);
-	    out->step_type = RECODE_BYTE_TO_STRING;
-	    out->step_table = string;
+            for (counter = 0; counter < 256; counter++)
+              string[counter] = table[accum[counter]];
+            free (accum);
+            out->step_type = RECODE_BYTE_TO_STRING;
+            out->step_table = string;
             if (in->step_table_term_routine)
               {
                 out->local = (void *) table;   /* Save reference to old table for destructor.  */
                 out->term_routine = delete_compressed_one_to_many;
               }
             out->step_table_term_routine = free;
-	    out->transform_routine = transform_byte_to_variable;
-	    out->after = in->after;
-	    merge_qualities (&out->quality, in->quality);
-	    in++;
-	    saved_steps++;
-	  }
-	else
-	  {
-	    /* Make the new single step be a one-to-one recoding.  */
+            out->transform_routine = transform_byte_to_variable;
+            out->after = in->after;
+            merge_qualities (&out->quality, in->quality);
+            in++;
+            saved_steps++;
+          }
+        else
+          {
+            /* Make the new single step be a one-to-one recoding.  */
 
-	    out->step_type = RECODE_BYTE_TO_BYTE;
-	    out->step_table = accum;
-	    out->transform_routine = transform_byte_to_byte;
-	  }
+            out->step_type = RECODE_BYTE_TO_BYTE;
+            out->step_table = accum;
+            out->transform_routine = transform_byte_to_byte;
+          }
 
-	out++;
+        out++;
       }
     else if (out != in)
       *out++ = *in++;
@@ -753,8 +753,8 @@ scan_identifier (RECODE_REQUEST request)
   char *cursor = request->scanned_string;
 
   while (*request->scan_cursor && *request->scan_cursor != ','
-	 && (request->scan_cursor[0] != '.' || request->scan_cursor[1] != '.')
-	 && *request->scan_cursor != '/' && *request->scan_cursor != '+')
+         && (request->scan_cursor[0] != '.' || request->scan_cursor[1] != '.')
+         && *request->scan_cursor != '/' && *request->scan_cursor != '+')
     *cursor++ = *request->scan_cursor++;
   *cursor = NUL;
 
@@ -776,25 +776,25 @@ scan_options (RECODE_REQUEST request)
   while (*request->scan_cursor == '+')
     {
       RECODE_OPTION_LIST new_
-	= ALLOC (new_, 1, struct recode_option_list);
+        = ALLOC (new_, 1, struct recode_option_list);
       char *copy;
 
       if (!new_)
-	break;			/* FIXME: should interrupt decoding */
+        break;                  /* FIXME: should interrupt decoding */
 
       request->scan_cursor++;
       scan_identifier (request);
       ALLOC (copy, strlen (request->scanned_string) + 1, char);
       if (!copy)
-	{
-	  free (new_);
-	  break;		/* FIXME: should interrupt decoding */
-	}
+        {
+          free (new_);
+          break;                /* FIXME: should interrupt decoding */
+        }
       strcpy (copy, request->scanned_string);
 
       new_->option = copy;
       if (!list)
-	list = new_;
+        list = new_;
       new_->next = last;
       last = new_;
     }
@@ -840,14 +840,14 @@ scan_unsurfacers (RECODE_REQUEST request)
   if (*request->scanned_string)
     {
       RECODE_ALIAS alias = find_alias (outer, request->scanned_string,
-					  ALIAS_FIND_AS_SURFACE);
+                                          ALIAS_FIND_AS_SURFACE);
 
       if (!alias)
-	{
-	  recode_error (outer, _("Unrecognised surface name `%s'"),
-			request->scanned_string);
-	  return false;
-	}
+        {
+          recode_error (outer, _("Unrecognised surface name `%s'"),
+                        request->scanned_string);
+          return false;
+        }
       surface = alias->symbol;
       /* FIXME: Should check that it does not itself have implied surfaces?  */
     }
@@ -872,7 +872,7 @@ scan_unsurfacers (RECODE_REQUEST request)
 
 static bool
 add_unsurfacers_to_sequence (RECODE_REQUEST request,
-			     struct recode_surface_list *list)
+                             struct recode_surface_list *list)
 {
   if (list->next)
     if (!add_unsurfacers_to_sequence (request, list->next))
@@ -900,9 +900,9 @@ add_unsurfacers_to_sequence (RECODE_REQUEST request,
 
 static RECODE_SYMBOL
 scan_charset (RECODE_REQUEST request,
-	      RECODE_CONST_SYMBOL before,
-	      RECODE_CONST_OPTION_LIST before_options,
-	      RECODE_OPTION_LIST *options_pointer)
+              RECODE_CONST_SYMBOL before,
+              RECODE_CONST_OPTION_LIST before_options,
+              RECODE_OPTION_LIST *options_pointer)
 {
   RECODE_OUTER outer = request->outer;
   RECODE_ALIAS alias;
@@ -922,65 +922,65 @@ scan_charset (RECODE_REQUEST request,
       /* We are scanning in an AFTER position.  */
 
       if (!find_sequence (request, before, before_options,
-			  charset, charset_options))
-	{
-	  recode_error (outer, _("No way to recode from `%s' to `%s'"),
-			before->name, charset->name);
-	  return NULL;
-	}
+                          charset, charset_options))
+        {
+          recode_error (outer, _("No way to recode from `%s' to `%s'"),
+                        before->name, charset->name);
+          return NULL;
+        }
 
       /* Ignore everything about surfaces, except in last position of a
-	 subrequest.  This optimises out the application of surfaces, when
-	 these would be immediately followed by their removal.  */
+         subrequest.  This optimises out the application of surfaces, when
+         these would be immediately followed by their removal.  */
 
       if (scan_check_if_last_charset (request))
-	{
-	  if (*request->scan_cursor == '/')
-	    {
-	      while (*request->scan_cursor == '/')
-		{
-		  RECODE_SYMBOL surface = NULL;
-		  RECODE_OPTION_LIST surface_options = NULL;
+        {
+          if (*request->scan_cursor == '/')
+            {
+              while (*request->scan_cursor == '/')
+                {
+                  RECODE_SYMBOL surface = NULL;
+                  RECODE_OPTION_LIST surface_options = NULL;
 
-		  request->scan_cursor++;
-		  scan_identifier (request);
-		  if (*request->scanned_string)
-		    {
-		      RECODE_ALIAS alias2
-			= find_alias (outer, request->scanned_string,
-				      ALIAS_FIND_AS_SURFACE);
+                  request->scan_cursor++;
+                  scan_identifier (request);
+                  if (*request->scanned_string)
+                    {
+                      RECODE_ALIAS alias2
+                        = find_alias (outer, request->scanned_string,
+                                      ALIAS_FIND_AS_SURFACE);
 
-		      if (!alias2)
-			{
-			  recode_error (outer,
-					_("Unrecognised surface name `%s'"),
-					request->scanned_string);
-			  return NULL;
-			}
-		      surface = alias2->symbol;
-		      /* FIXME: Should check that it does not itself have
-			 implied surfaces?  */
-		    }
-		  if (*request->scan_cursor == '+')
-		    surface_options = scan_options (request);
+                      if (!alias2)
+                        {
+                          recode_error (outer,
+                                        _("Unrecognised surface name `%s'"),
+                                        request->scanned_string);
+                          return NULL;
+                        }
+                      surface = alias2->symbol;
+                      /* FIXME: Should check that it does not itself have
+                         implied surfaces?  */
+                    }
+                  if (*request->scan_cursor == '+')
+                    surface_options = scan_options (request);
 
-		  if (surface && surface->resurfacer)
-		    if (!add_to_sequence (request, surface->resurfacer,
-					  NULL, surface_options))
-		      return NULL;
-		}
-	    }
-	  else if (alias->implied_surfaces && !request->make_header_flag)
-	    {
-	      struct recode_surface_list *list;
+                  if (surface && surface->resurfacer)
+                    if (!add_to_sequence (request, surface->resurfacer,
+                                          NULL, surface_options))
+                      return NULL;
+                }
+            }
+          else if (alias->implied_surfaces && !request->make_header_flag)
+            {
+              struct recode_surface_list *list;
 
-	      for (list = alias->implied_surfaces; list; list = list->next)
-		if (list->surface->resurfacer)
-		  if (!add_to_sequence (request, list->surface->resurfacer,
-					NULL, NULL))
-		    return NULL;
-	    }
-	}
+              for (list = alias->implied_surfaces; list; list = list->next)
+                if (list->surface->resurfacer)
+                  if (!add_to_sequence (request, list->surface->resurfacer,
+                                        NULL, NULL))
+                    return NULL;
+            }
+        }
     }
   else
     {
@@ -989,15 +989,15 @@ scan_charset (RECODE_REQUEST request,
       *options_pointer = charset_options;
 
       if (*request->scan_cursor == '/')
-	{
-	  if (!scan_unsurfacers (request))
-	    return NULL;
-	}
+        {
+          if (!scan_unsurfacers (request))
+            return NULL;
+        }
       else if (alias->implied_surfaces && !request->make_header_flag)
-	{
-	  if (!add_unsurfacers_to_sequence (request, alias->implied_surfaces))
-	    return NULL;
-	}
+        {
+          if (!add_unsurfacers_to_sequence (request, alias->implied_surfaces))
+            return NULL;
+        }
     }
 
   return charset;
@@ -1020,17 +1020,17 @@ scan_request (RECODE_REQUEST request)
   if (request->scan_cursor[0] == '.' && request->scan_cursor[1] == '.')
     while (request->scan_cursor[0] == '.' && request->scan_cursor[1] == '.')
       {
-	request->scan_cursor += 2;
-	charset = scan_charset (request, charset, options, NULL);
-	if (!charset)
-	  return false;
+        request->scan_cursor += 2;
+        charset = scan_charset (request, charset, options, NULL);
+        if (!charset)
+          return false;
       }
   else if (*request->scan_cursor == NUL)
     {
       /* No `..' at all implies a conversion to the default charset.  */
       charset = scan_charset (request, charset, options, NULL);
       if (!charset)
-	return false;
+        return false;
     }
   else
     {
@@ -1059,19 +1059,19 @@ decode_request (RECODE_REQUEST request, const char *string)
   if (*request->scan_cursor)
     {
       if (!scan_request (request))
-	{
-	  free (request->scanned_string);
-	  return false;
-	}
+        {
+          free (request->scanned_string);
+          return false;
+        }
       while (*request->scan_cursor == ',')
-	{
-	  request->scan_cursor++;
-	  if (!scan_request (request))
-	    {
-	      free (request->scanned_string);
-	      return false;
-	    }
-	}
+        {
+          request->scan_cursor++;
+          if (!scan_request (request))
+            {
+              free (request->scanned_string);
+              return false;
+            }
+        }
     }
 
   free (request->scanned_string);
@@ -1099,10 +1099,10 @@ guarantee_nul_terminator (RECODE_TASK task)
       size_t size = task->output.cursor - task->output.buffer;
 
       if (REALLOC (task->output.buffer, size + 4, char))
-	{
-	  task->output.cursor = task->output.buffer + size;
-	  task->output.limit = task->output.buffer + size + 4;
-	}
+        {
+          task->output.cursor = task->output.buffer + size;
+          task->output.limit = task->output.buffer + size + 4;
+        }
       else
         return false;
     }
@@ -1158,40 +1158,40 @@ recode_string (RECODE_CONST_REQUEST request, const char *input_string)
   size_t output_allocated = 0;
 
   recode_buffer_to_buffer (request, input_string, strlen (input_string),
-			   &output_buffer, &output_length, &output_allocated);
+                           &output_buffer, &output_length, &output_allocated);
   return output_buffer;
 }
 
 bool
 recode_string_to_buffer (RECODE_CONST_REQUEST request,
-			 const char *input_string,
-			 char **output_buffer_pointer,
-			 size_t *output_length_pointer,
-			 size_t *output_allocated_pointer)
+                         const char *input_string,
+                         char **output_buffer_pointer,
+                         size_t *output_length_pointer,
+                         size_t *output_allocated_pointer)
 {
   return
     recode_buffer_to_buffer (request, input_string, strlen (input_string),
-			     output_buffer_pointer, output_length_pointer,
-			     output_allocated_pointer);
+                             output_buffer_pointer, output_length_pointer,
+                             output_allocated_pointer);
 }
 
 bool
 recode_string_to_file (RECODE_CONST_REQUEST request,
-		       const char *input_string,
-		       FILE *output_file)
+                       const char *input_string,
+                       FILE *output_file)
 {
   return
     recode_buffer_to_file (request, input_string, strlen (input_string),
-			   output_file);
+                           output_file);
 }
 
 bool
 recode_buffer_to_buffer (RECODE_CONST_REQUEST request,
-			 const char *input_buffer,
-			 size_t input_length,
-			 char **output_buffer_pointer,
-			 size_t *output_length_pointer,
-			 size_t *output_allocated_pointer)
+                         const char *input_buffer,
+                         size_t input_length,
+                         char **output_buffer_pointer,
+                         size_t *output_length_pointer,
+                         size_t *output_allocated_pointer)
 {
   RECODE_TASK task = recode_new_task (request);
   bool success;
@@ -1217,9 +1217,9 @@ recode_buffer_to_buffer (RECODE_CONST_REQUEST request,
 
 bool
 recode_buffer_to_file (RECODE_CONST_REQUEST request,
-		       const char *input_buffer,
-		       size_t input_length,
-		       FILE *output_file)
+                       const char *input_buffer,
+                       size_t input_length,
+                       FILE *output_file)
 {
   RECODE_TASK task = recode_new_task (request);
   bool success;
@@ -1240,10 +1240,10 @@ recode_buffer_to_file (RECODE_CONST_REQUEST request,
 
 bool
 recode_file_to_buffer (RECODE_CONST_REQUEST request,
-		       FILE *input_file,
-		       char **output_buffer_pointer,
-		       size_t *output_length_pointer,
-		       size_t *output_allocated_pointer)
+                       FILE *input_file,
+                       char **output_buffer_pointer,
+                       size_t *output_length_pointer,
+                       size_t *output_allocated_pointer)
 {
   RECODE_TASK task = recode_new_task (request);
   bool success;
@@ -1267,8 +1267,8 @@ recode_file_to_buffer (RECODE_CONST_REQUEST request,
 
 bool
 recode_file_to_file (RECODE_CONST_REQUEST request,
-		     FILE *input_file,
-		     FILE *output_file)
+                     FILE *input_file,
+                     FILE *output_file)
 {
   RECODE_TASK task = recode_new_task (request);
   bool success;

--- a/src/rfc1345.c
+++ b/src/rfc1345.c
@@ -27,7 +27,7 @@
 
 /*----------------------------------------------------------------------.
 | Return an RFC 1345 short form in a CHARSET for a given UCS2 value, or |
-| NULL if this value has no such known short form.		        |
+| NULL if this value has no such known short form.                      |
 `----------------------------------------------------------------------*/
 
 _GL_ATTRIBUTE_PURE const char *
@@ -42,11 +42,11 @@ ucs2_to_rfc1345 (recode_ucs2 code)
       const struct entry *entry = &table[middle];
 
       if (entry->code < code)
-	first = middle + 1;
+        first = middle + 1;
       else if (entry->code > code)
-	last = middle;
+        last = middle;
       else
-	return entry->rfc1345;
+        return entry->rfc1345;
     }
 
   return NULL;
@@ -70,11 +70,11 @@ rfc1345_to_ucs2 (const char *string)
       int value = strcmp (entry->rfc1345, string);
 
       if (value < 0)
-	first = middle + 1;
+        first = middle + 1;
       else if (value > 0)
-	last = middle;
+        last = middle;
       else
-	return entry->code;
+        return entry->code;
     }
 
   return NOT_A_CHARACTER;
@@ -84,7 +84,7 @@ rfc1345_to_ucs2 (const char *string)
 
 struct local
 {
-  char intro;			/* RFC 1345 intro character */
+  char intro;                   /* RFC 1345 intro character */
 };
 
 /*-----------------------------------------------.
@@ -101,39 +101,39 @@ transform_ucs2_rfc1345 (RECODE_SUBTASK subtask)
   while (get_ucs2 (&value, subtask))
     if (IS_ASCII (value))
       if (value == (unsigned)intro)
-	{
-	  put_byte (intro, subtask);
-	  put_byte (intro, subtask);
-	}
+        {
+          put_byte (intro, subtask);
+          put_byte (intro, subtask);
+        }
       else
-	put_byte (value, subtask);
+        put_byte (value, subtask);
     else
       {
-	const char *string = ucs2_to_rfc1345 (value);
+        const char *string = ucs2_to_rfc1345 (value);
 
-	if (!string || !string[0])
-	  RETURN_IF_NOGO (RECODE_UNTRANSLATABLE, subtask);
-	else if (!string[1])
-	  put_byte (string[0], subtask);
-	else if (!string[2])
-	  {
-	    put_byte (intro, subtask);
-	    put_byte (string[0], subtask);
-	    put_byte (string[1], subtask);
-	  }
-	else
-	  {
-	    const char *cursor = string;
+        if (!string || !string[0])
+          RETURN_IF_NOGO (RECODE_UNTRANSLATABLE, subtask);
+        else if (!string[1])
+          put_byte (string[0], subtask);
+        else if (!string[2])
+          {
+            put_byte (intro, subtask);
+            put_byte (string[0], subtask);
+            put_byte (string[1], subtask);
+          }
+        else
+          {
+            const char *cursor = string;
 
-	    put_byte (intro, subtask);
-	    put_byte ('_', subtask);
-	    while (*cursor)
-	      {
-		put_byte (*cursor, subtask);
-		cursor++;
-	      }
-	    put_byte ('_', subtask);
-	  }
+            put_byte (intro, subtask);
+            put_byte ('_', subtask);
+            while (*cursor)
+              {
+                put_byte (*cursor, subtask);
+                cursor++;
+              }
+            put_byte ('_', subtask);
+          }
       }
 
   SUBTASK_RETURN (subtask);
@@ -154,69 +154,69 @@ transform_rfc1345_ucs2 (RECODE_SUBTASK subtask)
 
     if (character == intro)
       {
-	character = get_byte (subtask);
-	if (character == EOF)
-	  RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+        character = get_byte (subtask);
+        if (character == EOF)
+          RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
 
-	if (character == intro)
-	  put_ucs2 (intro, subtask);
-	else if (character == '_')
-	  {
-	    char buffer[MAX_MNEMONIC_LENGTH + 1];
-	    char *cursor = buffer;
+        if (character == intro)
+          put_ucs2 (intro, subtask);
+        else if (character == '_')
+          {
+            char buffer[MAX_MNEMONIC_LENGTH + 1];
+            char *cursor = buffer;
 
-	    character = get_byte (subtask);
-	    while (true)
-	      if (character == EOF)
-		{
-		  RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-		  break;
-		}
-	      else if (character == '_')
-		{
-		  recode_ucs2 value;
+            character = get_byte (subtask);
+            while (true)
+              if (character == EOF)
+                {
+                  RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+                  break;
+                }
+              else if (character == '_')
+                {
+                  recode_ucs2 value;
 
-		  *cursor = NUL;
-		  value = rfc1345_to_ucs2 (buffer);
-		  if (value == NOT_A_CHARACTER)
-		    RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-		  else
-		    put_ucs2 (value, subtask);
-		  break;
-		}
-	      else if (cursor == buffer + MAX_MNEMONIC_LENGTH)
-		{
-		  RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-		  break;
-		}
-	      else
-		{
-		  *cursor++ = character;
-		  character = get_byte (subtask);
-		}
-	  }
-	else
-	  {
-	    char buffer[3];
-	    recode_ucs2 value;
+                  *cursor = NUL;
+                  value = rfc1345_to_ucs2 (buffer);
+                  if (value == NOT_A_CHARACTER)
+                    RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+                  else
+                    put_ucs2 (value, subtask);
+                  break;
+                }
+              else if (cursor == buffer + MAX_MNEMONIC_LENGTH)
+                {
+                  RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+                  break;
+                }
+              else
+                {
+                  *cursor++ = character;
+                  character = get_byte (subtask);
+                }
+          }
+        else
+          {
+            char buffer[3];
+            recode_ucs2 value;
 
-	    buffer[0] = character;
-	    character = get_byte (subtask);
-	    if (character == EOF)
-	      RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-	    buffer[1] = character;
-	    buffer[2] = NUL;
+            buffer[0] = character;
+            character = get_byte (subtask);
+            if (character == EOF)
+              RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+            buffer[1] = character;
+            buffer[2] = NUL;
 
-	    value = rfc1345_to_ucs2 (buffer);
-	    if (value == NOT_A_CHARACTER)
-	      RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-	    else
-	      {
-		if (IS_ASCII (value))
-		  RETURN_IF_NOGO (RECODE_AMBIGUOUS_OUTPUT, subtask);
-		put_ucs2 (value, subtask);
-	      }
-	  }
+            value = rfc1345_to_ucs2 (buffer);
+            if (value == NOT_A_CHARACTER)
+              RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+            else
+              {
+                if (IS_ASCII (value))
+                  RETURN_IF_NOGO (RECODE_AMBIGUOUS_OUTPUT, subtask);
+                put_ucs2 (value, subtask);
+              }
+          }
       }
     else
       put_ucs2 (character, subtask);
@@ -237,8 +237,8 @@ term_rfc1345 (RECODE_STEP step)
 
 static bool
 init_rfc1345 (RECODE_CONST_REQUEST request,
-	      RECODE_STEP step,
-	      RECODE_CONST_OPTION_LIST options _GL_UNUSED)
+              RECODE_STEP step,
+              RECODE_CONST_OPTION_LIST options _GL_UNUSED)
 {
   RECODE_OUTER outer = request->outer;
   struct local *local;
@@ -255,9 +255,9 @@ init_rfc1345 (RECODE_CONST_REQUEST request,
 
 static bool
 init_ucs2_rfc1345 (RECODE_STEP step,
-		   RECODE_CONST_REQUEST request,
-		   RECODE_CONST_OPTION_LIST before_options,
-		   RECODE_CONST_OPTION_LIST after_options)
+                   RECODE_CONST_REQUEST request,
+                   RECODE_CONST_OPTION_LIST before_options,
+                   RECODE_CONST_OPTION_LIST after_options)
 {
   if (before_options)
     return false;
@@ -267,9 +267,9 @@ init_ucs2_rfc1345 (RECODE_STEP step,
 
 static bool
 init_rfc1345_ucs2 (RECODE_STEP step,
-		   RECODE_CONST_REQUEST request,
-		   RECODE_CONST_OPTION_LIST before_options,
-		   RECODE_CONST_OPTION_LIST after_options)
+                   RECODE_CONST_REQUEST request,
+                   RECODE_CONST_OPTION_LIST before_options,
+                   RECODE_CONST_OPTION_LIST after_options)
 {
   if (after_options)
     return false;

--- a/src/task.c
+++ b/src/task.c
@@ -28,7 +28,7 @@
 #include "minmax.h"
 #include "xbinary-io.h"
 
-bool recode_interrupted = 0;	/* set by signal handler when some signal has been received */
+bool recode_interrupted = 0;    /* set by signal handler when some signal has been received */
 
 
 /* Input and output helpers.  */
@@ -158,10 +158,10 @@ transform_mere_copy (RECODE_SUBTASK subtask)
       size_t size;
 
       while (size = get_bytes (subtask, buffer, BUFSIZ),
-	     size == BUFSIZ)
-	put_bytes (buffer, BUFSIZ, subtask);
+             size == BUFSIZ)
+        put_bytes (buffer, BUFSIZ, subtask);
       if (size > 0)
-	put_bytes (buffer, size, subtask);
+        put_bytes (buffer, size, subtask);
     }
   else
     /* Reading from buffer.  */
@@ -205,10 +205,10 @@ transform_byte_to_variable (RECODE_SUBTASK subtask)
   while (input_char = get_byte (subtask), input_char != EOF)
     if (output_string = table[input_char], output_string)
       while (*output_string)
-	{
-	  put_byte (*output_string, subtask);
-	  output_string++;
-	}
+        {
+          put_byte (*output_string, subtask);
+          output_string++;
+        }
    else
      RETURN_IF_NOGO (RECODE_UNTRANSLATABLE, subtask);
 
@@ -230,8 +230,8 @@ recode_perform_task (RECODE_TASK task)
   RECODE_SUBTASK subtask = &subtask_block;
 
 #if HAVE_PIPE
-  int pipe_pair[2];		/* pair of file descriptors for a pipe */
-  pid_t wait_status;		/* status returned by wait() */
+  int pipe_pair[2];             /* pair of file descriptors for a pipe */
+  pid_t wait_status;            /* status returned by wait() */
 #endif
 
   struct recode_read_write_text input;
@@ -260,19 +260,19 @@ recode_perform_task (RECODE_TASK task)
   if (subtask->input.name)
     {
       if (!*subtask->input.name)
-	subtask->input.file = stdin;
+        subtask->input.file = stdin;
       else if (subtask->input.file = fopen (subtask->input.name, "rb"),
-	       subtask->input.file == NULL)
-	{
-	  recode_perror (NULL, "fopen (%s)", subtask->input.name);
-	  recode_if_nogo (RECODE_SYSTEM_ERROR, subtask);
-	  SUBTASK_RETURN (subtask);
-	}
+               subtask->input.file == NULL)
+        {
+          recode_perror (NULL, "fopen (%s)", subtask->input.name);
+          recode_if_nogo (RECODE_SYSTEM_ERROR, subtask);
+          SUBTASK_RETURN (subtask);
+        }
     }
 
   /* Execute one pass for each step of the sequence.  */
 
-  int child_process = -1;	/* child process number, -1 if process has not forked */
+  int child_process = -1;       /* child process number, -1 if process has not forked */
   for (unsigned sequence_index = 0;
        task->error_so_far < task->abort_level;
        sequence_index++)
@@ -292,7 +292,7 @@ recode_perform_task (RECODE_TASK task)
       /* Select the output text for this step.  */
 
       if (sequence_index + 1 < (unsigned)request->sequence_length)
-	{
+        {
           subtask->output = output;
           subtask->output.cursor = subtask->output.buffer;
 
@@ -359,70 +359,70 @@ recode_perform_task (RECODE_TASK task)
                 fclose (subtask->input.file);
             }
 #endif
-	}
+        }
       else
-	{
-	  /* Prepare the final output file.  */
+        {
+          /* Prepare the final output file.  */
 
-	  subtask->output = task->output;
-	  if (subtask->output.name)
-	    {
-	      if (!*subtask->output.name)
-		subtask->output.file = stdout;
-	      else if (subtask->output.file = fopen (subtask->output.name, "wb"),
-		       subtask->output.file == NULL)
-		{
-		  recode_perror (NULL, "fopen (%s)", subtask->output.name);
-		  recode_if_nogo (RECODE_SYSTEM_ERROR, subtask);
-		  goto exit;
-		}
-	    }
-	}
+          subtask->output = task->output;
+          if (subtask->output.name)
+            {
+              if (!*subtask->output.name)
+                subtask->output.file = stdout;
+              else if (subtask->output.file = fopen (subtask->output.name, "wb"),
+                       subtask->output.file == NULL)
+                {
+                  recode_perror (NULL, "fopen (%s)", subtask->output.name);
+                  recode_if_nogo (RECODE_SYSTEM_ERROR, subtask);
+                  goto exit;
+                }
+            }
+        }
 
       /* Execute one recoding step.  */
 
       if (request->sequence_length == 0) {
-	transform_mere_copy (subtask);
-	break;
+        transform_mere_copy (subtask);
+        break;
       }
 
       if (child_process <= 0)
-	{
-	  subtask->step = request->sequence_array + sequence_index;
-	  (*subtask->step->transform_routine) (subtask);
+        {
+          subtask->step = request->sequence_array + sequence_index;
+          (*subtask->step->transform_routine) (subtask);
 
 #if HAVE_PIPE
-          break;	/* child/top-level process: escape from loop */
+          break;        /* child/top-level process: escape from loop */
 #else
-	  /* Post-step clean up for memory sequence.  */
+          /* Post-step clean up for memory sequence.  */
 
-	  if (subtask->input.file)
-	    {
-	      FILE *fp = subtask->input.file;
+          if (subtask->input.file)
+            {
+              FILE *fp = subtask->input.file;
 
-	      subtask->input.file = NULL;
-	      if (fclose (fp) != 0)
-		{
-		  recode_perror (NULL, "fclose (%s)", subtask->input.name);
-		  recode_if_nogo (RECODE_SYSTEM_ERROR, subtask);
-		  goto exit;
-		}
-	    }
+              subtask->input.file = NULL;
+              if (fclose (fp) != 0)
+                {
+                  recode_perror (NULL, "fclose (%s)", subtask->input.name);
+                  recode_if_nogo (RECODE_SYSTEM_ERROR, subtask);
+                  goto exit;
+                }
+            }
 
-	  /* Prepare for next step.  */
+          /* Prepare for next step.  */
 
-	  task->swap_input = RECODE_SWAP_UNDECIDED;
+          task->swap_input = RECODE_SWAP_UNDECIDED;
 
-	  if (sequence_index + 1 < (unsigned)request->sequence_length)
-	    {
-	      output = input;
-	      input = subtask->output;
-	    }
+          if (sequence_index + 1 < (unsigned)request->sequence_length)
+            {
+              output = input;
+              input = subtask->output;
+            }
 #endif
-	}
+        }
 
       if (sequence_index + 1 == (unsigned)request->sequence_length)
-	break;
+        break;
     }
 
   /* Final clean up.  */

--- a/src/testdump.c
+++ b/src/testdump.c
@@ -81,10 +81,10 @@ test15_data (RECODE_SUBTASK subtask)
       case REPLACEMENT_CHARACTER:
       case BYTE_ORDER_MARK_SWAPPED:
       case NOT_A_CHARACTER:
-	break;
+        break;
 
       default:
-	put_ucs2 (counter, subtask);
+        put_ucs2 (counter, subtask);
       }
 
   /* Copy the rest verbatim.  */
@@ -116,8 +116,8 @@ test16_data (RECODE_SUBTASK subtask)
 
 struct ucs2_to_count
   {
-    recode_ucs2 code;		/* UCS-2 value */
-    unsigned count;		/* corresponding count */
+    recode_ucs2 code;           /* UCS-2 value */
+    unsigned count;             /* corresponding count */
   };
 
 static size_t
@@ -163,45 +163,45 @@ static bool
 produce_count (RECODE_SUBTASK subtask)
 {
   RECODE_OUTER outer = subtask->task->request->outer;
-  Hash_table *table;		/* hash table for UCS-2 characters */
-  size_t size;			/* number of different characters */
-  struct ucs2_to_count **array;	/* array into hash table items */
+  Hash_table *table;            /* hash table for UCS-2 characters */
+  size_t size;                  /* number of different characters */
+  struct ucs2_to_count **array; /* array into hash table items */
 
   table = hash_initialize (0, NULL,
-			   ucs2_to_count_hash, ucs2_to_count_compare, free);
+                           ucs2_to_count_hash, ucs2_to_count_compare, free);
   if (!table)
     return false;
 
   /* Count characters.  */
 
   {
-    unsigned character;		/* current character being counted */
+    unsigned character;         /* current character being counted */
 
     while (get_ucs2 (&character, subtask))
       {
-	struct ucs2_to_count lookup;
-	struct ucs2_to_count *entry;
+        struct ucs2_to_count lookup;
+        struct ucs2_to_count *entry;
 
-	lookup.code = character;
-	entry = (struct ucs2_to_count *) hash_lookup (table, &lookup);
-	if (entry)
-	  entry->count++;
-	else
-	  {
-	    if (!ALLOC (entry, 1, struct ucs2_to_count))
-	      {
-		hash_free (table);
-		return false;
-	      }
-	    entry->code = character;
-	    entry->count = 1;
-	    if (!hash_insert (table, entry))
-	      {
-		hash_free (table);
-		free (entry);
-		return false;
-	      }
-	  }
+        lookup.code = character;
+        entry = (struct ucs2_to_count *) hash_lookup (table, &lookup);
+        if (entry)
+          entry->count++;
+        else
+          {
+            if (!ALLOC (entry, 1, struct ucs2_to_count))
+              {
+                hash_free (table);
+                return false;
+              }
+            entry->code = character;
+            entry->count = 1;
+            if (!hash_insert (table, entry))
+              {
+                hash_free (table);
+                free (entry);
+                return false;
+              }
+          }
       }
   }
 
@@ -233,7 +233,7 @@ produce_count (RECODE_SUBTASK subtask)
 
     for (cursor = array; cursor < array + size; cursor++)
       if ((*cursor)->count > maximum_count)
-	maximum_count = (*cursor)->count;
+        maximum_count = (*cursor)->count;
     if (asprintf (&buffer, "%u", maximum_count) == -1)
       return false;
     count_width = strlen (buffer);
@@ -241,36 +241,36 @@ produce_count (RECODE_SUBTASK subtask)
 
     for (cursor = array; cursor < array + size; cursor++)
       {
-	unsigned character = (*cursor)->code;
-	const char *mnemonic = ucs2_to_rfc1345 (character);
+        unsigned character = (*cursor)->code;
+        const char *mnemonic = ucs2_to_rfc1345 (character);
 
-	if (column + count_width + non_count_width > 80)
-	  {
-	    put_byte ('\n', subtask);
-	    delayed = 0;
-	    column = 0;
-	  }
-	else
-	  while (delayed)
-	    {
-	      put_byte (' ', subtask);
-	      delayed--;
-	    }
+        if (column + count_width + non_count_width > 80)
+          {
+            put_byte ('\n', subtask);
+            delayed = 0;
+            column = 0;
+          }
+        else
+          while (delayed)
+            {
+              put_byte (' ', subtask);
+              delayed--;
+            }
 
-	if (asprintf (&buffer, "%*u  %.4X", (int)count_width, (*cursor)->count, character) == -1)
+        if (asprintf (&buffer, "%*u  %.4X", (int)count_width, (*cursor)->count, character) == -1)
           return false;
         put_string (buffer, subtask);
         free (buffer);
-	if (mnemonic)
-	  {
-	    put_byte (' ', subtask);
-	    put_string (mnemonic, subtask);
-	    delayed = 6 - 1 - strlen (mnemonic);
-	  }
-	else
-	  delayed = 6;
+        if (mnemonic)
+          {
+            put_byte (' ', subtask);
+            put_string (mnemonic, subtask);
+            delayed = 6 - 1 - strlen (mnemonic);
+          }
+        else
+          delayed = 6;
 
-	column += count_width + non_count_width;
+        column += count_width + non_count_width;
       }
 
     if (column)
@@ -292,55 +292,55 @@ produce_count (RECODE_SUBTASK subtask)
 static bool
 produce_full_dump (RECODE_SUBTASK subtask)
 {
-  unsigned character;		/* character to dump */
+  unsigned character;           /* character to dump */
 
   /* Dump all characters.  */
 
   if (get_ucs2 (&character, subtask))
     {
       bool french = should_prefer_french();
-      const char *charname;	/* charname for code */
+      const char *charname;     /* charname for code */
       char buffer[50];
 
       put_string (_("UCS2   Mne   Description\n\n"), subtask);
 
       while (1)
-	{
-	  const char *mnemonic = ucs2_to_rfc1345 (character);
+        {
+          const char *mnemonic = ucs2_to_rfc1345 (character);
 
-	  sprintf (buffer, "%.4X", character);
+          sprintf (buffer, "%.4X", character);
           put_string (buffer, subtask);
-	  if (mnemonic)
+          if (mnemonic)
             {
               sprintf (buffer, "   %-3s", mnemonic);
               put_string (buffer, subtask);
             }
-	  else
-	    put_string ("      ", subtask);
+          else
+            put_string ("      ", subtask);
 
-	  if (french)
-	    {
-	      charname = ucs2_to_french_charname (character);
-	      if (!charname)
-		charname = ucs2_to_charname (character);
-	    }
-	  else
-	    {
-	      charname = ucs2_to_charname (character);
-	      if (!charname)
-		charname = ucs2_to_french_charname (character);
-	    }
+          if (french)
+            {
+              charname = ucs2_to_french_charname (character);
+              if (!charname)
+                charname = ucs2_to_charname (character);
+            }
+          else
+            {
+              charname = ucs2_to_charname (character);
+              if (!charname)
+                charname = ucs2_to_french_charname (character);
+            }
 
-	  if (charname)
-	    {
-	      put_string ("   ", subtask);
-	      put_string (charname, subtask);
-	    }
-	  put_byte ('\n', subtask);
+          if (charname)
+            {
+              put_string ("   ", subtask);
+              put_string (charname, subtask);
+            }
+          put_byte ('\n', subtask);
 
-	  if (!get_ucs2 (&character, subtask))
-	    break;
-	}
+          if (!get_ucs2 (&character, subtask))
+            break;
+        }
     }
 
   SUBTASK_RETURN (subtask);
@@ -356,31 +356,31 @@ module_testdump (RECODE_OUTER outer)
   /* Test surfaces.  */
 
   if (!declare_single (outer, "test7", "data",
-		       outer->quality_variable_to_byte,
-		       NULL, test7_data))
+                       outer->quality_variable_to_byte,
+                       NULL, test7_data))
     return false;
   if (!declare_single (outer, "test8", "data",
-		       outer->quality_variable_to_byte,
-		       NULL, test8_data))
+                       outer->quality_variable_to_byte,
+                       NULL, test8_data))
     return false;
   if (!declare_single (outer, "test15", "data",
-		       outer->quality_variable_to_ucs2,
-		       NULL, test15_data))
+                       outer->quality_variable_to_ucs2,
+                       NULL, test15_data))
     return false;
   if (!declare_single (outer, "test16", "data",
-		       outer->quality_variable_to_ucs2,
-		       NULL, test16_data))
+                       outer->quality_variable_to_ucs2,
+                       NULL, test16_data))
     return false;
 
   /* Analysis charsets.  */
 
   if (!declare_single (outer, "ISO-10646-UCS-2", "count-characters",
-		       outer->quality_ucs2_to_variable,
-		       NULL, produce_count))
+                       outer->quality_ucs2_to_variable,
+                       NULL, produce_count))
     return false;
   if (!declare_single (outer, "ISO-10646-UCS-2", "dump-with-names",
-		       outer->quality_ucs2_to_variable,
-		       NULL, produce_full_dump))
+                       outer->quality_ucs2_to_variable,
+                       NULL, produce_full_dump))
     return false;
 
   return true;

--- a/src/txtelat1.l
+++ b/src/txtelat1.l
@@ -25,122 +25,122 @@ void texte_latin1_diaeresis (void);
 
 %}
 
-s			(^|[^a-zA-Z])
-d			[:"]
-l			[a-zA-Z]
+s                       (^|[^a-zA-Z])
+d                       [:"]
+l                       [a-zA-Z]
 %%
 
-``			{ put_byte (171, subtask); }
-''			{ put_byte (187, subtask); }
+``                      { put_byte (171, subtask); }
+''                      { put_byte (187, subtask); }
 
-A`			{ put_byte (192, subtask); }
-A^			{ put_byte (194, subtask); }
-A{d}/{l}		{ if (yytext[1] == request->diaeresis_char)
-			    put_byte (196, subtask);
-			  else
-			    ECHO;
-			}
-a`			{ put_byte (224, subtask); }
-a^			{ put_byte (226, subtask); }
-a{d}/{l}		{ if (yytext[1] == request->diaeresis_char)
-			    put_byte (228, subtask);
-			  else
-			    ECHO;
-			}
+A`                      { put_byte (192, subtask); }
+A^                      { put_byte (194, subtask); }
+A{d}/{l}                { if (yytext[1] == request->diaeresis_char)
+                            put_byte (196, subtask);
+                          else
+                            ECHO;
+                        }
+a`                      { put_byte (224, subtask); }
+a^                      { put_byte (226, subtask); }
+a{d}/{l}                { if (yytext[1] == request->diaeresis_char)
+                            put_byte (228, subtask);
+                          else
+                            ECHO;
+                        }
 
-C\,/[aAoOuU]		{ put_byte (199, subtask); }
-c\,/[aAoOuU]		{ put_byte (231, subtask); }
+C\,/[aAoOuU]            { put_byte (199, subtask); }
+c\,/[aAoOuU]            { put_byte (231, subtask); }
 
-E`			{ put_byte (200, subtask); }
-E'''			{ put_byte (201, subtask); put_byte (187, subtask); }
-E''			{ put_byte ('E', subtask); put_byte (187, subtask); }
-E'			{ put_byte (201, subtask); }
-E^			{ put_byte (202, subtask); }
-E{d}/{l}		{ if (yytext[1] == request->diaeresis_char)
-			    put_byte (203, subtask);
-			  else
-			    ECHO;
-			}
-e`			{ put_byte (232, subtask); }
-e'''			{ put_byte (233, subtask); put_byte (187, subtask); }
-e''			{ put_byte ('e', subtask); put_byte (187, subtask); }
-e'			{ put_byte (233, subtask); }
-e^			{ put_byte (234, subtask); }
-e{d}/{l}		{ if (yytext[1] == request->diaeresis_char)
-			    put_byte (235, subtask);
-			  else
-			    ECHO;
-			}
+E`                      { put_byte (200, subtask); }
+E'''                    { put_byte (201, subtask); put_byte (187, subtask); }
+E''                     { put_byte ('E', subtask); put_byte (187, subtask); }
+E'                      { put_byte (201, subtask); }
+E^                      { put_byte (202, subtask); }
+E{d}/{l}                { if (yytext[1] == request->diaeresis_char)
+                            put_byte (203, subtask);
+                          else
+                            ECHO;
+                        }
+e`                      { put_byte (232, subtask); }
+e'''                    { put_byte (233, subtask); put_byte (187, subtask); }
+e''                     { put_byte ('e', subtask); put_byte (187, subtask); }
+e'                      { put_byte (233, subtask); }
+e^                      { put_byte (234, subtask); }
+e{d}/{l}                { if (yytext[1] == request->diaeresis_char)
+                            put_byte (235, subtask);
+                          else
+                            ECHO;
+                        }
 
-I`			{ put_byte (204, subtask); }
-I^			{ put_byte (206, subtask); }
-I{d}/{l}		{ if (yytext[1] == request->diaeresis_char)
-			    put_byte (207, subtask);
-			  else
-			    ECHO;
-			}
-i`			{ put_byte (236, subtask); }
-i^			{ put_byte (238, subtask); }
-i{d}/{l}		{ if (yytext[1] == request->diaeresis_char)
-			    put_byte (239, subtask);
-			  else
-			    ECHO;
-			}
+I`                      { put_byte (204, subtask); }
+I^                      { put_byte (206, subtask); }
+I{d}/{l}                { if (yytext[1] == request->diaeresis_char)
+                            put_byte (207, subtask);
+                          else
+                            ECHO;
+                        }
+i`                      { put_byte (236, subtask); }
+i^                      { put_byte (238, subtask); }
+i{d}/{l}                { if (yytext[1] == request->diaeresis_char)
+                            put_byte (239, subtask);
+                          else
+                            ECHO;
+                        }
 
-O`			{ put_byte (210, subtask); }
-O^			{ put_byte (212, subtask); }
-O{d}/{l}		{ if (yytext[1] == request->diaeresis_char)
-			    put_byte (214, subtask);
-			  else
-			    ECHO;
-			}
-o`			{ put_byte (242, subtask); }
-o^			{ put_byte (244, subtask); }
-o{d}/{l}		{ if (yytext[1] == request->diaeresis_char)
-			    put_byte (246, subtask);
-			  else
-			    ECHO;
-			}
+O`                      { put_byte (210, subtask); }
+O^                      { put_byte (212, subtask); }
+O{d}/{l}                { if (yytext[1] == request->diaeresis_char)
+                            put_byte (214, subtask);
+                          else
+                            ECHO;
+                        }
+o`                      { put_byte (242, subtask); }
+o^                      { put_byte (244, subtask); }
+o{d}/{l}                { if (yytext[1] == request->diaeresis_char)
+                            put_byte (246, subtask);
+                          else
+                            ECHO;
+                        }
 
-U`			{ put_byte (217, subtask); }
-U^			{ put_byte (219, subtask); }
-U{d}/{l}		{ if (yytext[1] == request->diaeresis_char)
-			    put_byte (220, subtask);
-			  else
-			    ECHO;
-			}
-u`			{ put_byte (249, subtask); }
-u^			{ put_byte (251, subtask); }
-u{d}/{l}		{ if (yytext[1] == request->diaeresis_char)
-			    put_byte (252, subtask);
-			  else
-			    ECHO;
-			}
+U`                      { put_byte (217, subtask); }
+U^                      { put_byte (219, subtask); }
+U{d}/{l}                { if (yytext[1] == request->diaeresis_char)
+                            put_byte (220, subtask);
+                          else
+                            ECHO;
+                        }
+u`                      { put_byte (249, subtask); }
+u^                      { put_byte (251, subtask); }
+u{d}/{l}                { if (yytext[1] == request->diaeresis_char)
+                            put_byte (252, subtask);
+                          else
+                            ECHO;
+                        }
 
-{s}[Bb]esaigue{d}	{ texte_latin1_diaeresis (); }
-{s}[Cc]igue{d}		{ texte_latin1_diaeresis (); }
-{s}[Aa]igue{d}		{ texte_latin1_diaeresis (); }
-{s}[Aa]mbigue{d}	{ texte_latin1_diaeresis (); }
-{s}[Cc]ontigue{d}	{ texte_latin1_diaeresis (); }
-{s}[Ee]xigue{d}		{ texte_latin1_diaeresis (); }
-{s}[Ss]ubaigue{d}	{ texte_latin1_diaeresis (); }
-{s}[Ss]uraigue{d}	{ texte_latin1_diaeresis (); }
-{s}[Aa]i{d}		{ texte_latin1_diaeresis (); }
-{s}[Cc]ongai{d}		{ texte_latin1_diaeresis (); }
-{s}[Gg]oi{d}		{ texte_latin1_diaeresis (); }
-{s}[Hh]ai{d}kai{d}	{ if (yytext[4] == request->diaeresis_char)
-			    texte_latin1_diaeresis ();
-			  else
-			    ECHO;
-			}
-{s}[Ii]noui{d}		{ texte_latin1_diaeresis (); }
-[JjTtLl]'[Aa][Ii]{d}	{ ECHO; }
-{s}[Ss]ai{d}		{ texte_latin1_diaeresis (); }
-{s}[Ss]amurai{d}	{ texte_latin1_diaeresis (); }
-{s}[Tt]hai{d}		{ texte_latin1_diaeresis (); }
-{s}[Tt]okai{d}		{ texte_latin1_diaeresis (); }
-{s}[Cc]anoe{d}		{ texte_latin1_diaeresis (); }
-{s}Esau{d}		{ texte_latin1_diaeresis (); }
+{s}[Bb]esaigue{d}       { texte_latin1_diaeresis (); }
+{s}[Cc]igue{d}          { texte_latin1_diaeresis (); }
+{s}[Aa]igue{d}          { texte_latin1_diaeresis (); }
+{s}[Aa]mbigue{d}        { texte_latin1_diaeresis (); }
+{s}[Cc]ontigue{d}       { texte_latin1_diaeresis (); }
+{s}[Ee]xigue{d}         { texte_latin1_diaeresis (); }
+{s}[Ss]ubaigue{d}       { texte_latin1_diaeresis (); }
+{s}[Ss]uraigue{d}       { texte_latin1_diaeresis (); }
+{s}[Aa]i{d}             { texte_latin1_diaeresis (); }
+{s}[Cc]ongai{d}         { texte_latin1_diaeresis (); }
+{s}[Gg]oi{d}            { texte_latin1_diaeresis (); }
+{s}[Hh]ai{d}kai{d}      { if (yytext[4] == request->diaeresis_char)
+                            texte_latin1_diaeresis ();
+                          else
+                            ECHO;
+                        }
+{s}[Ii]noui{d}          { texte_latin1_diaeresis (); }
+[JjTtLl]'[Aa][Ii]{d}    { ECHO; }
+{s}[Ss]ai{d}            { texte_latin1_diaeresis (); }
+{s}[Ss]amurai{d}        { texte_latin1_diaeresis (); }
+{s}[Tt]hai{d}           { texte_latin1_diaeresis (); }
+{s}[Tt]okai{d}          { texte_latin1_diaeresis (); }
+{s}[Cc]anoe{d}          { texte_latin1_diaeresis (); }
+{s}Esau{d}              { texte_latin1_diaeresis (); }
 %%
 
 void
@@ -151,26 +151,26 @@ texte_latin1_diaeresis (void)
   for (counter = 0; counter < yyleng; counter++)
     if (yytext[counter+1] == request->diaeresis_char)
       {
-	switch (yytext[counter])
-	  {
-	    /* The next "case 'A'" line once triggered a `NULL in input'
-	       diagnostic in flex.  This astonishing bug has been hard to
-	       isolate, so I'll leave this comment around for a while.  */
+        switch (yytext[counter])
+          {
+            /* The next "case 'A'" line once triggered a `NULL in input'
+               diagnostic in flex.  This astonishing bug has been hard to
+               isolate, so I'll leave this comment around for a while.  */
 
-	  case 'A': put_byte (196, subtask); break;
-	  case 'E': put_byte (203, subtask); break;
-	  case 'I': put_byte (207, subtask); break;
-	  case 'O': put_byte (214, subtask); break;
-	  case 'U': put_byte (220, subtask); break;
-	  case 'a': put_byte (228, subtask); break;
-	  case 'e': put_byte (235, subtask); break;
-	  case 'i': put_byte (239, subtask); break;
-	  case 'o': put_byte (246, subtask); break;
-	  case 'u': put_byte (252, subtask); break;
-	  case 'y': put_byte (255, subtask); break;
-	  default:  put_byte (yytext[counter], subtask);
-	  }
-	counter++;
+          case 'A': put_byte (196, subtask); break;
+          case 'E': put_byte (203, subtask); break;
+          case 'I': put_byte (207, subtask); break;
+          case 'O': put_byte (214, subtask); break;
+          case 'U': put_byte (220, subtask); break;
+          case 'a': put_byte (228, subtask); break;
+          case 'e': put_byte (235, subtask); break;
+          case 'i': put_byte (239, subtask); break;
+          case 'o': put_byte (246, subtask); break;
+          case 'u': put_byte (252, subtask); break;
+          case 'y': put_byte (255, subtask); break;
+          default:  put_byte (yytext[counter], subtask);
+          }
+        counter++;
       }
     else
       put_byte (yytext[counter], subtask);
@@ -181,8 +181,8 @@ module_texte_latin1 (RECODE_OUTER outer)
 {
   return
     declare_single (outer, "Texte", "Latin-1",
-		    outer->quality_variable_to_byte, NULL,
-		    transform_texte_latin1)
+                    outer->quality_variable_to_byte, NULL,
+                    transform_texte_latin1)
     && declare_alias (outer, "txte", "Texte");
 }
 

--- a/src/ucs.c
+++ b/src/ucs.c
@@ -386,78 +386,78 @@ get_ucs2 (unsigned *value, RECODE_SUBTASK subtask)
 
       character1 = get_byte (subtask);
       if (character1 == EOF)
-	return false;
+        return false;
       character2 = get_byte (subtask);
       if (character2 == EOF)
-	{
-	  recode_if_nogo (RECODE_INVALID_INPUT, subtask);
-	  return false;
-	}
+        {
+          recode_if_nogo (RECODE_INVALID_INPUT, subtask);
+          return false;
+        }
 
       switch (subtask->task->swap_input)
-	{
-	case RECODE_SWAP_UNDECIDED:
-	  chunk = ((BIT_MASK (8) & character1) << 8) | (BIT_MASK (8) & character2);
-	  switch (chunk)
-	    {
-	    case BYTE_ORDER_MARK:
-	      subtask->task->swap_input = RECODE_SWAP_NO;
-	      break;
+        {
+        case RECODE_SWAP_UNDECIDED:
+          chunk = ((BIT_MASK (8) & character1) << 8) | (BIT_MASK (8) & character2);
+          switch (chunk)
+            {
+            case BYTE_ORDER_MARK:
+              subtask->task->swap_input = RECODE_SWAP_NO;
+              break;
 
-	    case BYTE_ORDER_MARK_SWAPPED:
-	      subtask->task->swap_input = RECODE_SWAP_YES;
-	      break;
+            case BYTE_ORDER_MARK_SWAPPED:
+              subtask->task->swap_input = RECODE_SWAP_YES;
+              break;
 
-	    default:
-	      *value = chunk;
-	      subtask->task->swap_input = RECODE_SWAP_NO;
-	      if (subtask->task->byte_order_mark)
-		RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
-	      return true;
-	    }
-	  break;
+            default:
+              *value = chunk;
+              subtask->task->swap_input = RECODE_SWAP_NO;
+              if (subtask->task->byte_order_mark)
+                RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
+              return true;
+            }
+          break;
 
-	case RECODE_SWAP_NO:
-	  chunk = ((BIT_MASK (8) & character1) << 8) | (BIT_MASK (8) & character2);
-	  switch (chunk)
-	    {
-	    case BYTE_ORDER_MARK:
-	      RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
-	      break;
+        case RECODE_SWAP_NO:
+          chunk = ((BIT_MASK (8) & character1) << 8) | (BIT_MASK (8) & character2);
+          switch (chunk)
+            {
+            case BYTE_ORDER_MARK:
+              RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
+              break;
 
-	    case BYTE_ORDER_MARK_SWAPPED:
-	      subtask->task->swap_input = RECODE_SWAP_YES;
-	      RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
-	      break;
+            case BYTE_ORDER_MARK_SWAPPED:
+              subtask->task->swap_input = RECODE_SWAP_YES;
+              RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
+              break;
 
-	    default:
-	      *value = chunk;
-	      return true;
-	    }
-	  break;
+            default:
+              *value = chunk;
+              return true;
+            }
+          break;
 
-	case RECODE_SWAP_YES:
-	  chunk = ((BIT_MASK (8) & character2) << 8) | (BIT_MASK (8) & character1);
-	  switch (chunk)
-	    {
-	    case BYTE_ORDER_MARK:
-	      RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
-	      break;
+        case RECODE_SWAP_YES:
+          chunk = ((BIT_MASK (8) & character2) << 8) | (BIT_MASK (8) & character1);
+          switch (chunk)
+            {
+            case BYTE_ORDER_MARK:
+              RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
+              break;
 
-	    case BYTE_ORDER_MARK_SWAPPED:
-	      subtask->task->swap_input = RECODE_SWAP_NO;
-	      RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
-	      break;
+            case BYTE_ORDER_MARK_SWAPPED:
+              subtask->task->swap_input = RECODE_SWAP_NO;
+              RETURN_IF_NOGO (RECODE_NOT_CANONICAL, subtask);
+              break;
 
-	    default:
-	      *value = chunk;
-	      return true;
-	    }
-	  break;
+            default:
+              *value = chunk;
+              return true;
+            }
+          break;
 
         default:
           break;
-	}
+        }
     }
 }
 
@@ -540,9 +540,9 @@ put_ucs4 (unsigned value, RECODE_SUBTASK subtask)
 
 static bool
 init_combined_ucs2 (RECODE_STEP step,
-		    RECODE_CONST_REQUEST request,
-		    RECODE_CONST_OPTION_LIST before_options,
-		    RECODE_CONST_OPTION_LIST after_options)
+                    RECODE_CONST_REQUEST request,
+                    RECODE_CONST_OPTION_LIST before_options,
+                    RECODE_CONST_OPTION_LIST after_options)
 {
   step->before->data_type = RECODE_EXPLODE_DATA;
   step->before->data = (void *) combining_data;
@@ -551,9 +551,9 @@ init_combined_ucs2 (RECODE_STEP step,
 
 static bool
 init_ucs2_combined (RECODE_STEP step,
-		    RECODE_CONST_REQUEST request,
-		    RECODE_CONST_OPTION_LIST before_options,
-		    RECODE_CONST_OPTION_LIST after_options)
+                    RECODE_CONST_REQUEST request,
+                    RECODE_CONST_OPTION_LIST before_options,
+                    RECODE_CONST_OPTION_LIST after_options)
 {
   step->after->data_type = RECODE_EXPLODE_DATA;
   step->after->data = (void *) combining_data;
@@ -599,17 +599,17 @@ module_ucs (RECODE_OUTER outer)
 {
   return
     declare_single (outer, "combined-UCS-2", "ISO-10646-UCS-2",
-		    outer->quality_ucs2_to_variable,
-		    init_combined_ucs2, explode_ucs2_ucs2)
+                    outer->quality_ucs2_to_variable,
+                    init_combined_ucs2, explode_ucs2_ucs2)
     && declare_single (outer, "ISO-10646-UCS-2", "combined-UCS-2",
-		       outer->quality_variable_to_ucs2,
-		       init_ucs2_combined, combine_ucs2_ucs2)
+                       outer->quality_variable_to_ucs2,
+                       init_ucs2_combined, combine_ucs2_ucs2)
     && declare_single (outer, "latin1", "ISO-10646-UCS-4",
-		       outer->quality_byte_to_variable,
-		       NULL, transform_latin1_ucs4)
+                       outer->quality_byte_to_variable,
+                       NULL, transform_latin1_ucs4)
     && declare_single (outer, "ISO-10646-UCS-2", "ISO-10646-UCS-4",
-		       outer->quality_variable_to_variable,
-		       NULL, transform_ucs2_ucs4)
+                       outer->quality_variable_to_variable,
+                       NULL, transform_ucs2_ucs4)
 
     && declare_alias (outer, "UCS", "ISO-10646-UCS-4")
     && declare_alias (outer, "UCS-4", "ISO-10646-UCS-4")

--- a/src/utf16.c
+++ b/src/utf16.c
@@ -29,36 +29,36 @@ transform_ucs4_utf16 (RECODE_SUBTASK subtask)
   if (get_ucs4 (&value, subtask))
     {
       if (subtask->task->byte_order_mark)
-	put_ucs2 (BYTE_ORDER_MARK, subtask);
+        put_ucs2 (BYTE_ORDER_MARK, subtask);
 
       while (true)
-	{
-	  if (value & ~BIT_MASK (16))
-	    if (value < (1 << 16 | 1 << 20))
-	      {
-		/* Double UCS-2 character.  */
+        {
+          if (value & ~BIT_MASK (16))
+            if (value < (1 << 16 | 1 << 20))
+              {
+                /* Double UCS-2 character.  */
 
-		value -= 1 << 16;
-		put_ucs2 (0xD800 | (BIT_MASK (10) & value >> 10), subtask);
-		put_ucs2 (0xDC00 | (BIT_MASK (10) & value), subtask);
-	      }
-	    else
-	      {
-		RETURN_IF_NOGO (RECODE_UNTRANSLATABLE, subtask);
-		put_ucs2 (REPLACEMENT_CHARACTER, subtask);
-	      }
-	  else
-	    {
-	      /* Single UCS-2 character.  */
+                value -= 1 << 16;
+                put_ucs2 (0xD800 | (BIT_MASK (10) & value >> 10), subtask);
+                put_ucs2 (0xDC00 | (BIT_MASK (10) & value), subtask);
+              }
+            else
+              {
+                RETURN_IF_NOGO (RECODE_UNTRANSLATABLE, subtask);
+                put_ucs2 (REPLACEMENT_CHARACTER, subtask);
+              }
+          else
+            {
+              /* Single UCS-2 character.  */
 
-	      if (value >= 0xD800 && value < 0xE000)
-		RETURN_IF_NOGO (RECODE_AMBIGUOUS_OUTPUT, subtask);
-	      put_ucs2 (value, subtask);
-	    }
+              if (value >= 0xD800 && value < 0xE000)
+                RETURN_IF_NOGO (RECODE_AMBIGUOUS_OUTPUT, subtask);
+              put_ucs2 (value, subtask);
+            }
 
-	  if (!get_ucs4 (&value, subtask))
-	    break;
-	}
+          if (!get_ucs4 (&value, subtask))
+            break;
+        }
     }
 
   SUBTASK_RETURN (subtask);
@@ -72,44 +72,44 @@ transform_utf16_ucs4 (RECODE_SUBTASK subtask)
   if (get_ucs2 (&value, subtask))
     {
       while (true)
-	if (value >= 0xD800 && value < 0xE000)
-	  if (value < 0xDC00)
-	    {
-	      unsigned chunk;
+        if (value >= 0xD800 && value < 0xE000)
+          if (value < 0xDC00)
+            {
+              unsigned chunk;
 
-	      if (!get_ucs2 (&chunk, subtask))
-		break;
+              if (!get_ucs2 (&chunk, subtask))
+                break;
 
-	      if (chunk >= 0xDC00 && chunk < 0xE000)
-		{
-		  put_ucs4 ((((1 << 16) + ((value - 0xD800) << 10))
-			     | (chunk - 0xDC00)),
-			    subtask);
-		  if (!get_ucs2 (&value, subtask))
-		    break;
-		}
-	      else
-		{
-		  /* Discard the first chunk if the pair is invalid.  */
+              if (chunk >= 0xDC00 && chunk < 0xE000)
+                {
+                  put_ucs4 ((((1 << 16) + ((value - 0xD800) << 10))
+                             | (chunk - 0xDC00)),
+                            subtask);
+                  if (!get_ucs2 (&value, subtask))
+                    break;
+                }
+              else
+                {
+                  /* Discard the first chunk if the pair is invalid.  */
 
-		  RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-		  value = chunk;
-		}
-	    }
-	  else
-	    {
-	      /* Discard a second chunk when presented first.  */
+                  RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+                  value = chunk;
+                }
+            }
+          else
+            {
+              /* Discard a second chunk when presented first.  */
 
-	      RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-	      if (!get_ucs2 (&value, subtask))
-		break;
-	    }
-	else
-	  {
-	    put_ucs4 (value, subtask);
-	    if (!get_ucs2 (&value, subtask))
-	      break;
-	  }
+              RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+              if (!get_ucs2 (&value, subtask))
+                break;
+            }
+        else
+          {
+            put_ucs4 (value, subtask);
+            if (!get_ucs2 (&value, subtask))
+              break;
+          }
     }
 
   SUBTASK_RETURN (subtask);
@@ -126,7 +126,7 @@ transform_ucs2_utf16 (RECODE_SUBTASK subtask)
   while (get_ucs2 (&value, subtask))
     {
       if (value >= 0xD800 && value < 0xE000)
-	RETURN_IF_NOGO (RECODE_AMBIGUOUS_OUTPUT, subtask);
+        RETURN_IF_NOGO (RECODE_AMBIGUOUS_OUTPUT, subtask);
       put_ucs2 (value, subtask);
     }
 
@@ -145,46 +145,46 @@ transform_utf16_ucs2 (RECODE_SUBTASK subtask)
   if (get_ucs2 (&value, subtask))
     {
       if (subtask->task->byte_order_mark)
-	put_ucs2 (BYTE_ORDER_MARK, subtask);
+        put_ucs2 (BYTE_ORDER_MARK, subtask);
 
       while (true)
-	if (value >= 0xD800 && value < 0xE000)
-	  if (value < 0xDC00)
-	    {
-	      unsigned chunk;
+        if (value >= 0xD800 && value < 0xE000)
+          if (value < 0xDC00)
+            {
+              unsigned chunk;
 
-	      if (!get_ucs2 (&chunk, subtask))
-		break;
+              if (!get_ucs2 (&chunk, subtask))
+                break;
 
-	      if (chunk >= 0xDC00 && chunk < 0xE000)
-		{
-		  RETURN_IF_NOGO (RECODE_UNTRANSLATABLE, subtask);
-		  put_ucs2 (REPLACEMENT_CHARACTER, subtask);
-		  if (!get_ucs2 (&value, subtask))
-		    break;
-		}
-	      else
-		{
-		  /* Discard the first chunk if the pair is invalid.  */
+              if (chunk >= 0xDC00 && chunk < 0xE000)
+                {
+                  RETURN_IF_NOGO (RECODE_UNTRANSLATABLE, subtask);
+                  put_ucs2 (REPLACEMENT_CHARACTER, subtask);
+                  if (!get_ucs2 (&value, subtask))
+                    break;
+                }
+              else
+                {
+                  /* Discard the first chunk if the pair is invalid.  */
 
-		  RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-		  value = chunk;
-		}
-	    }
-	  else
-	    {
-	      /* Discard a second chunk when presented first.  */
+                  RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+                  value = chunk;
+                }
+            }
+          else
+            {
+              /* Discard a second chunk when presented first.  */
 
-	      RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-	      if (!get_ucs2 (&value, subtask))
-		break;
-	    }
-	else
-	  {
-	    put_ucs2 (value, subtask);
-	    if (!get_ucs2 (&value, subtask))
-	      break;
-	  }
+              RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+              if (!get_ucs2 (&value, subtask))
+                break;
+            }
+        else
+          {
+            put_ucs2 (value, subtask);
+            if (!get_ucs2 (&value, subtask))
+              break;
+          }
     }
 
   SUBTASK_RETURN (subtask);
@@ -195,17 +195,17 @@ module_utf16 (RECODE_OUTER outer)
 {
   return
     declare_single (outer, "ISO-10646-UCS-4", "UTF-16",
-		    outer->quality_variable_to_variable,
-		    NULL, transform_ucs4_utf16)
+                    outer->quality_variable_to_variable,
+                    NULL, transform_ucs4_utf16)
     && declare_single (outer, "UTF-16", "ISO-10646-UCS-4",
-		       outer->quality_variable_to_variable,
-		       NULL, transform_utf16_ucs4)
+                       outer->quality_variable_to_variable,
+                       NULL, transform_utf16_ucs4)
     && declare_single (outer, "ISO-10646-UCS-2", "UTF-16",
-		       outer->quality_variable_to_variable,
-		       NULL, transform_ucs2_utf16)
+                       outer->quality_variable_to_variable,
+                       NULL, transform_ucs2_utf16)
     && declare_single (outer, "UTF-16", "ISO-10646-UCS-2",
-		       outer->quality_variable_to_variable,
-		       NULL, transform_utf16_ucs2)
+                       outer->quality_variable_to_variable,
+                       NULL, transform_utf16_ucs2)
 
     && declare_alias (outer, "Unicode", "UTF-16")
     && declare_alias (outer, "TF-16", "UTF-16")

--- a/src/utf8.c
+++ b/src/utf8.c
@@ -25,17 +25,17 @@
    This macro is meant to be used only within the `while' loop in
    `transform_utf8_ucs[24]'.  */
 #define GET_DATA_BYTE \
-  character = get_byte (subtask);						\
-  if (character == EOF)							\
-    {									\
-      RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);		\
-      break;								\
-    }									\
-  else if ((BIT_MASK (2) << 6 & character) != 1 << 7)			\
-    {									\
-      RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);		\
-      continue;								\
-    }									\
+  character = get_byte (subtask);                                               \
+  if (character == EOF)                                                 \
+    {                                                                   \
+      RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);           \
+      break;                                                            \
+    }                                                                   \
+  else if ((BIT_MASK (2) << 6 & character) != 1 << 7)                   \
+    {                                                                   \
+      RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);           \
+      continue;                                                         \
+    }                                                                   \
   else
 
 /* Read next data byte and check its value, discard an illegal sequence.
@@ -52,22 +52,22 @@ transform_ucs2_utf8 (RECODE_SUBTASK subtask)
   while (get_ucs2 (&value, subtask))
     {
       if (value & ~BIT_MASK (7))
-	if (value & ~BIT_MASK (11))
-	  {
-	    /* 3 bytes - more than 11 bits, but not more than 16.  */
-	    put_byte ((BIT_MASK (3) << 5) | (BIT_MASK (6) & value >> 12), subtask);
-	    put_byte ((1 << 7) | (BIT_MASK (6) & value >> 6), subtask);
-	    put_byte ((1 << 7) | (BIT_MASK (6) & value), subtask);
-	  }
-	else
-	  {
-	    /* 2 bytes - more than 7 bits, but not more than 11.  */
-	    put_byte ((BIT_MASK (2) << 6) | (BIT_MASK (6) & value >> 6), subtask);
-	    put_byte ((1 << 7) | (BIT_MASK (6) & value), subtask);
-	  }
+        if (value & ~BIT_MASK (11))
+          {
+            /* 3 bytes - more than 11 bits, but not more than 16.  */
+            put_byte ((BIT_MASK (3) << 5) | (BIT_MASK (6) & value >> 12), subtask);
+            put_byte ((1 << 7) | (BIT_MASK (6) & value >> 6), subtask);
+            put_byte ((1 << 7) | (BIT_MASK (6) & value), subtask);
+          }
+        else
+          {
+            /* 2 bytes - more than 7 bits, but not more than 11.  */
+            put_byte ((BIT_MASK (2) << 6) | (BIT_MASK (6) & value >> 6), subtask);
+            put_byte ((1 << 7) | (BIT_MASK (6) & value), subtask);
+          }
       else
-	/* 1 byte - not more than 7 bits (that is, ASCII).  */
-	put_byte (value, subtask);
+        /* 1 byte - not more than 7 bits (that is, ASCII).  */
+        put_byte (value, subtask);
     }
 
   SUBTASK_RETURN (subtask);
@@ -81,51 +81,51 @@ transform_ucs4_utf8 (RECODE_SUBTASK subtask)
   while (get_ucs4 (&value, subtask))
     if (value & ~BIT_MASK (16))
       if (value & ~BIT_MASK (26))
-	if (value & ~BIT_MASK (31))
-	  {
-	    RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-	  }
-  	else
-	  {
-	    /* 6 bytes - more than 26 bits, but not more than 31.  */
-	    put_byte ((BIT_MASK (6) << 2) | (BIT_MASK (6) & value >> 30), subtask);
-	    put_byte ((1 << 7) | (BIT_MASK (6) & value >> 24), subtask);
-	    put_byte ((1 << 7) | (BIT_MASK (6) & value >> 18), subtask);
-	    put_byte ((1 << 7) | (BIT_MASK (6) & value >> 12), subtask);
-	    put_byte ((1 << 7) | (BIT_MASK (6) & value >> 6), subtask);
-	    put_byte ((1 << 7) | (BIT_MASK (6) & value), subtask);
-	  }
+        if (value & ~BIT_MASK (31))
+          {
+            RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+          }
+        else
+          {
+            /* 6 bytes - more than 26 bits, but not more than 31.  */
+            put_byte ((BIT_MASK (6) << 2) | (BIT_MASK (6) & value >> 30), subtask);
+            put_byte ((1 << 7) | (BIT_MASK (6) & value >> 24), subtask);
+            put_byte ((1 << 7) | (BIT_MASK (6) & value >> 18), subtask);
+            put_byte ((1 << 7) | (BIT_MASK (6) & value >> 12), subtask);
+            put_byte ((1 << 7) | (BIT_MASK (6) & value >> 6), subtask);
+            put_byte ((1 << 7) | (BIT_MASK (6) & value), subtask);
+          }
       else if (value & ~BIT_MASK (21))
-	{
-	  /* 5 bytes - more than 21 bits, but not more than 26.  */
-	  put_byte ((BIT_MASK (5) << 3) | (BIT_MASK (6) & value >> 24), subtask);
-	  put_byte ((1 << 7) | (BIT_MASK (6) & value >> 18), subtask);
-	  put_byte ((1 << 7) | (BIT_MASK (6) & value >> 12), subtask);
-	  put_byte ((1 << 7) | (BIT_MASK (6) & value >> 6), subtask);
-	  put_byte ((1 << 7) | (BIT_MASK (6) & value), subtask);
-	}
+        {
+          /* 5 bytes - more than 21 bits, but not more than 26.  */
+          put_byte ((BIT_MASK (5) << 3) | (BIT_MASK (6) & value >> 24), subtask);
+          put_byte ((1 << 7) | (BIT_MASK (6) & value >> 18), subtask);
+          put_byte ((1 << 7) | (BIT_MASK (6) & value >> 12), subtask);
+          put_byte ((1 << 7) | (BIT_MASK (6) & value >> 6), subtask);
+          put_byte ((1 << 7) | (BIT_MASK (6) & value), subtask);
+        }
       else
-	{
-	  /* 4 bytes - more than 16 bits, but not more than 21.  */
-	  put_byte ((BIT_MASK (4) << 4) | (BIT_MASK (6) & value >> 18), subtask);
-	  put_byte ((1 << 7) | (BIT_MASK (6) & value >> 12), subtask);
-	  put_byte ((1 << 7) | (BIT_MASK (6) & value >> 6), subtask);
-	  put_byte ((1 << 7) | (BIT_MASK (6) & value), subtask);
-	}
+        {
+          /* 4 bytes - more than 16 bits, but not more than 21.  */
+          put_byte ((BIT_MASK (4) << 4) | (BIT_MASK (6) & value >> 18), subtask);
+          put_byte ((1 << 7) | (BIT_MASK (6) & value >> 12), subtask);
+          put_byte ((1 << 7) | (BIT_MASK (6) & value >> 6), subtask);
+          put_byte ((1 << 7) | (BIT_MASK (6) & value), subtask);
+        }
     else if (value & ~BIT_MASK (7))
       if (value & ~BIT_MASK (11))
-	{
-	  /* 3 bytes - more than 11 bits, but not more than 16.  */
-	  put_byte ((BIT_MASK (3) << 5) | (BIT_MASK (6) & value >> 12), subtask);
-	  put_byte ((1 << 7) | (BIT_MASK (6) & value >> 6), subtask);
-	  put_byte ((1 << 7) | (BIT_MASK (6) & value), subtask);
-	}
+        {
+          /* 3 bytes - more than 11 bits, but not more than 16.  */
+          put_byte ((BIT_MASK (3) << 5) | (BIT_MASK (6) & value >> 12), subtask);
+          put_byte ((1 << 7) | (BIT_MASK (6) & value >> 6), subtask);
+          put_byte ((1 << 7) | (BIT_MASK (6) & value), subtask);
+        }
       else
-	{
-	  /* 2 bytes - more than 7 bits, but not more than 11.  */
-	  put_byte ((BIT_MASK (2) << 6) | (BIT_MASK (6) & value >> 6), subtask);
-	  put_byte ((1 << 7) | (BIT_MASK (6) & value), subtask);
-	}
+        {
+          /* 2 bytes - more than 7 bits, but not more than 11.  */
+          put_byte ((BIT_MASK (2) << 6) | (BIT_MASK (6) & value >> 6), subtask);
+          put_byte ((1 << 7) | (BIT_MASK (6) & value), subtask);
+        }
     else
       /* 1 byte - not more than 7 bits (that is, ASCII).  */
       put_byte (value, subtask);
@@ -150,74 +150,74 @@ transform_utf8_ucs4 (RECODE_SUBTASK subtask)
 
     if ((character & BIT_MASK (4) << 4) == BIT_MASK (4) << 4)
       if ((character & BIT_MASK (6) << 2) == BIT_MASK (6) << 2)
-	if ((character & BIT_MASK (7) << 1) == BIT_MASK (7) << 1)
-	  {
-	    /* 7 bytes - more than 31 bits (that is, exactly 32 :-).  */
-	    RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-	    character = get_byte (subtask);
-	  }
-	else
-	  {
-	    /* 6 bytes - more than 26 bits, but not more than 31.  */
-	    value = (BIT_MASK (1) & character) << 30;
-	    GET_DATA_BYTE_AT (24);
-	    GET_DATA_BYTE_AT (18);
-	    GET_DATA_BYTE_AT (12);
-	    GET_DATA_BYTE_AT (6);
-	    GET_DATA_BYTE_AT (0);
-	    put_ucs4 (value, subtask);
-	    character = get_byte (subtask);
-	  }
+        if ((character & BIT_MASK (7) << 1) == BIT_MASK (7) << 1)
+          {
+            /* 7 bytes - more than 31 bits (that is, exactly 32 :-).  */
+            RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+            character = get_byte (subtask);
+          }
+        else
+          {
+            /* 6 bytes - more than 26 bits, but not more than 31.  */
+            value = (BIT_MASK (1) & character) << 30;
+            GET_DATA_BYTE_AT (24);
+            GET_DATA_BYTE_AT (18);
+            GET_DATA_BYTE_AT (12);
+            GET_DATA_BYTE_AT (6);
+            GET_DATA_BYTE_AT (0);
+            put_ucs4 (value, subtask);
+            character = get_byte (subtask);
+          }
       else if ((character & BIT_MASK (5) << 3) == BIT_MASK (5) << 3)
-	{
-	  /* 5 bytes - more than 21 bits, but not more than 26.  */
-	  value = (BIT_MASK (2) & character) << 24;
-	  GET_DATA_BYTE_AT (18);
-	  GET_DATA_BYTE_AT (12);
-	  GET_DATA_BYTE_AT (6);
-	  GET_DATA_BYTE_AT (0);
-	  put_ucs4 (value, subtask);
-	  character = get_byte (subtask);
-	}
+        {
+          /* 5 bytes - more than 21 bits, but not more than 26.  */
+          value = (BIT_MASK (2) & character) << 24;
+          GET_DATA_BYTE_AT (18);
+          GET_DATA_BYTE_AT (12);
+          GET_DATA_BYTE_AT (6);
+          GET_DATA_BYTE_AT (0);
+          put_ucs4 (value, subtask);
+          character = get_byte (subtask);
+        }
       else
-	{
-	  /* 4 bytes - more than 16 bits, but not more than 21.  */
-	  value = (BIT_MASK (3) & character) << 18;
-	  GET_DATA_BYTE_AT (12);
-	  GET_DATA_BYTE_AT (6);
-	  GET_DATA_BYTE_AT (0);
-	  put_ucs4 (value, subtask);
-	  character = get_byte (subtask);
-	}
+        {
+          /* 4 bytes - more than 16 bits, but not more than 21.  */
+          value = (BIT_MASK (3) & character) << 18;
+          GET_DATA_BYTE_AT (12);
+          GET_DATA_BYTE_AT (6);
+          GET_DATA_BYTE_AT (0);
+          put_ucs4 (value, subtask);
+          character = get_byte (subtask);
+        }
     else if ((character & BIT_MASK (2) << 6) == BIT_MASK (2) << 6)
       if ((character & BIT_MASK (3) << 5) == BIT_MASK (3) << 5)
-	{
-	  /* 3 bytes - more than 11 bits, but not more than 16.  */
-	  value = (BIT_MASK (4) & character) << 12;
-	  GET_DATA_BYTE_AT (6);
-	  GET_DATA_BYTE_AT (0);
-	  put_ucs4 (value, subtask);
-	  character = get_byte (subtask);
-	}
+        {
+          /* 3 bytes - more than 11 bits, but not more than 16.  */
+          value = (BIT_MASK (4) & character) << 12;
+          GET_DATA_BYTE_AT (6);
+          GET_DATA_BYTE_AT (0);
+          put_ucs4 (value, subtask);
+          character = get_byte (subtask);
+        }
       else
-	{
-	  /* 2 bytes - more than 7 bits, but not more than 11.  */
-	  value = (BIT_MASK (5) & character) << 6;
-	  GET_DATA_BYTE_AT (0);
-	  put_ucs4 (value, subtask);
-	  character = get_byte (subtask);
-	}
+        {
+          /* 2 bytes - more than 7 bits, but not more than 11.  */
+          value = (BIT_MASK (5) & character) << 6;
+          GET_DATA_BYTE_AT (0);
+          put_ucs4 (value, subtask);
+          character = get_byte (subtask);
+        }
     else if ((character & 1 << 7) == 1 << 7)
       {
-	/* Valid only as a continuation byte.  */
-	RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
-	character = get_byte (subtask);
+        /* Valid only as a continuation byte.  */
+        RETURN_IF_NOGO (RECODE_INVALID_INPUT, subtask);
+        character = get_byte (subtask);
       }
     else
       {
-	/* 1 byte - not more than 7 bits (that is, ASCII).  */
-	put_ucs4 (BIT_MASK (8) & character, subtask);
-	character = get_byte (subtask);
+        /* 1 byte - not more than 7 bits (that is, ASCII).  */
+        put_ucs4 (BIT_MASK (8) & character, subtask);
+        character = get_byte (subtask);
       }
 
   SUBTASK_RETURN (subtask);
@@ -228,11 +228,11 @@ module_utf8 (RECODE_OUTER outer)
 {
   return
     declare_single (outer, "ISO-10646-UCS-4", "UTF-8",
-		    outer->quality_variable_to_variable,
-		    NULL, transform_ucs4_utf8)
+                    outer->quality_variable_to_variable,
+                    NULL, transform_ucs4_utf8)
     && declare_single (outer, "UTF-8", "ISO-10646-UCS-4",
-		       outer->quality_variable_to_variable,
-		       NULL, transform_utf8_ucs4)
+                       outer->quality_variable_to_variable,
+                       NULL, transform_utf8_ucs4)
 
     && declare_alias (outer, "UTF-2", "UTF-8")
     && declare_alias (outer, "UTF-FSS", "UTF-8")
@@ -242,8 +242,8 @@ module_utf8 (RECODE_OUTER outer)
 
     /* Simple UCS-2 does not have to go through UTF-16.  */
     && declare_single (outer, "ISO-10646-UCS-2", "UTF-8",
-		       outer->quality_variable_to_variable,
-		       NULL, transform_ucs2_utf8);
+                       outer->quality_variable_to_variable,
+                       NULL, transform_ucs2_utf8);
 }
 
 void

--- a/src/varia.c
+++ b/src/varia.c
@@ -72,7 +72,7 @@ static const unsigned short data_kamenicky[] =
     156, 0x013D, DONE,
     157, 0x00DD, DONE,
     158, 0x0158, DONE,
-    159, 0x0165, DONE,		/* latin small letter t with caron */
+    159, 0x0165, DONE,          /* latin small letter t with caron */
     160, 0x00E1, DONE,
     161, 0x00ED, DONE,
     162, 0x00F3, DONE,
@@ -150,10 +150,10 @@ static const unsigned short data_kamenicky[] =
     234, 0x03A9, DONE,
     235, 0x03B4, DONE,
     236, 0x221E, DONE,
-    237, 0x03C6, DONE,		/* greek small letter phi */
-    238, 0x03B5, DONE,		/* element of */
-    239, 0x2229, DONE,		/* intersection */
-    240, 0x224D, DONE,		/* equivalent to */
+    237, 0x03C6, DONE,          /* greek small letter phi */
+    238, 0x03B5, DONE,          /* element of */
+    239, 0x2229, DONE,          /* intersection */
+    240, 0x224D, DONE,          /* equivalent to */
     241, 0x00B1, DONE,
     242, 0x2265, DONE,
     243, 0x2264, DONE,
@@ -161,9 +161,9 @@ static const unsigned short data_kamenicky[] =
     245, 0x2321, DONE,
     246, 0x00F7, DONE,
     247, 0x2248, DONE,
-    248, 0x00B0, DONE,		/* degree sign */
-    249, 0x2219, DONE,		/* bullet operator */
-    250, 0x00B7, DONE,		/* middle dot */
+    248, 0x00B0, DONE,          /* degree sign */
+    249, 0x2219, DONE,          /* bullet operator */
+    250, 0x00B7, DONE,          /* middle dot */
     251, 0x221A, DONE,
     252, 0x207F, DONE,
     253, 0x00B2, DONE,
@@ -327,8 +327,8 @@ static const unsigned short data_koi8cs2[] =
     196, 0x010F, DONE,
     197, 0x011B, DONE,
     198, 0x0155, DONE,
-    199, DONE,			/* ch digraph as a single character,
-				   as used in the Czech alphabet, FIXME!  */
+    199, DONE,                  /* ch digraph as a single character,
+                                   as used in the Czech alphabet, FIXME!  */
     200, 0x00FC, DONE,
     201, 0x00ED, DONE,
     202, 0x016F, DONE,
@@ -359,8 +359,8 @@ static const unsigned short data_koi8cs2[] =
     228, 0x010E, DONE,
     229, 0x011A, DONE,
     230, 0x0154, DONE,
-    231, DONE,			/* CH digraph as a single character,
-				   as used in the Czech alphabet, FIXME!  */
+    231, DONE,                  /* CH digraph as a single character,
+                                   as used in the Czech alphabet, FIXME!  */
     232, 0x00DC, DONE,
     233, 0x00CD, DONE,
     234, 0x016E, DONE,


### PR DESCRIPTION
The source code previously used a mix of tabs and spaces for identation, which made everything look off when using an editor configured with tab width != 8.

Since effective identation width used in the source is 2, I think it is reasonable to just expand everything to spaces.

Also, since the identation width is 2, some editors will automatically detect the tab width to be 2.

Another option would be to add vim modelines or an `.editorconfig` file.
